### PR TITLE
Add Reasonable-based OWL-RL Reasoning capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
   - pip install poetry
-  - poetry install
+  - poetry install -E reasonable
 
 script:
   - pytest -s -vvvv

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -89,6 +89,48 @@ class OWLRLInferenceSession:
         return self.g.triples
 
 
+class OWLRLReasonableInferenceSession:
+    """
+    Provides methods and an inferface for producing the deductive closure
+    of a graph under OWL-RL semantics. WARNING this may take a long time
+    """
+
+    def __init__(self, load_brick=True):
+        """
+        Creates a new OWLRL Inference session
+
+        Args:
+            load_brick (bool): if True, load Brick ontology into the graph
+        """
+        from reasonable import PyReasoner
+        self.r = PyReasoner()
+        self.g = Graph(load_brick=load_brick)
+
+    def expand(self, graph):
+        """
+        Applies OWLRL reasoning from the Python owlrl library to the graph
+
+        Args:
+            graph (brickschema.graph.Graph): a Graph object containing triples
+
+        Returns:
+            graph (brickschema.graph.Graph): a Graph object containing the
+                inferred triples in addition to the regular graph
+        """
+        _inherit_bindings(graph, self.g)
+        for triple in graph:
+            self.g.add(triple)
+        self.r.from_graph(self.g.g)
+        triples = self.r.reason()
+        for t in triples:
+            self.g.add(t)
+        return _return_correct_type(graph, self.g)
+
+    @property
+    def triples(self):
+        return self.g.triples
+
+
 class OWLRLAllegroInferenceSession:
     """
     Provides methods and an inferface for producing the deductive closure

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -123,8 +123,18 @@ class OWLRLReasonableInferenceSession:
         self.r.from_graph(self.g.g)
         triples = self.r.reason()
         for t in triples:
+            t = tuple(map(self._to_rdflib_ident, t))
             self.g.add(t)
         return _return_correct_type(graph, self.g)
+
+    def _to_rdflib_ident(self, s):
+        try:
+            if s.startswith('http'):
+                return rdflib.URIRef(s)
+            else:
+                return rdflib.BNode(s)
+        except:
+            return rdflib.Literal(s)
 
     @property
     def triples(self):

--- a/brickschema/ontologies/Brick.ttl
+++ b/brickschema/ontologies/Brick.ttl
@@ -23,21 +23,43 @@
 
 brick:Absorption_Chiller a owl:Class ;
     rdfs:label "Absorption Chiller" ;
-    rdfs:subClassOf brick:Chiller .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Absorption ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    brick:hasAssociatedTag tag:Absorption,
+        tag:Chiller,
+        tag:Equipment .
 
 brick:Acceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Acceleration Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Acceleration ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Time_Setpoint ;
     brick:hasAssociatedTag tag:Acceleration,
+        tag:Point,
         tag:Setpoint,
         tag:Time .
 
+brick:Active_Power_Sensor a owl:Class ;
+    rdfs:label "Active Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Real ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Active_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
+        tag:Real,
+        tag:Sensor .
+
 brick:Air_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Air Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -46,64 +68,94 @@ brick:Air_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
+brick:Air_Flow_Loss_Alarm a owl:Class ;
+    rdfs:label "Air Flow Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm _:has_Flow _:has_Loss ) ],
+        brick:Air_Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Flow,
+        tag:Loss,
+        tag:Point .
+
 brick:Air_Handler_Unit a owl:Class ;
     rdfs:label "Air Handler Unit" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Handler ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:AHU ;
-    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system." .
+    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system." ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Handler,
+        tag:Unit .
 
 brick:Alarm_Delay_Parameter a owl:Class ;
     rdfs:label "Alarm Delay Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Alarm _:has_Delay _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm _:has_Delay _:has_Parameter ) ],
         brick:Delay_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Delay,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Automatic_Mode_Command a owl:Class ;
     rdfs:label "Automatic Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Automatic ;
+                        owl:onProperty brick:hasTag ] _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Automatic,
+        tag:Command,
+        tag:Mode,
+        tag:Point .
 
 brick:Average_Discharge_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Average Discharge Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Discharge _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Discharge _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Discharge_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Average_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Average Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Exhaust_Air_Static_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Average_Supply_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Average Supply Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Average _:has_Supply _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Supply _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Supply_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Average_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Average Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Average _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Average _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Average,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -128,16 +180,22 @@ brick:Battery a owl:Class ;
 
 brick:Battery_Voltage_Sensor a owl:Class ;
     rdfs:label "Battery Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Voltage _:has_Battery ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage _:has_Battery ) ],
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Battery,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
 brick:Boiler a owl:Class ;
     rdfs:label "Boiler" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Boiler ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications." ;
+    brick:hasAssociatedTag tag:Boiler,
+        tag:Equipment .
 
 brick:Booster_Fan a owl:Class ;
     rdfs:label "Booster Fan" ;
@@ -151,7 +209,12 @@ brick:Booster_Fan a owl:Class ;
 
 brick:Box_Mode_Command a owl:Class ;
     rdfs:label "Box Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Box _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Command,
+        tag:Mode,
+        tag:Point .
 
 brick:Building a owl:Class ;
     rdfs:label "Building" ;
@@ -163,7 +226,7 @@ brick:Building a owl:Class ;
 
 brick:Building_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Building Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -172,16 +235,18 @@ brick:Building_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Building,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Building_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Building Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Building,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
@@ -196,7 +261,7 @@ brick:Building_Meter a owl:Class ;
 
 brick:Bypass_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Bypass Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Bypass ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Bypass ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -206,34 +271,38 @@ brick:Bypass_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Bypass,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Bypass_Command a owl:Class ;
     rdfs:label "Bypass Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Bypass _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Bypass _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Bypass,
-        tag:Command .
+        tag:Command,
+        tag:Point .
 
 brick:CO2_Differential_Sensor a owl:Class ;
     rdfs:label "CO2 Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Differential _:has_Sensor ) ],
         brick:CO2_Sensor ;
     brick:hasAssociatedTag tag:CO2,
         tag:Differential,
+        tag:Point,
         tag:Sensor .
 
 brick:CO2_Level_Sensor a owl:Class ;
     rdfs:label "CO2 Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Level _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Level _:has_Sensor ) ],
         brick:CO2_Sensor ;
     brick:hasAssociatedTag tag:CO2,
         tag:Level,
+        tag:Point,
         tag:Sensor .
 
 brick:Capacity_Sensor a owl:Class ;
     rdfs:label "Capacity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Capacity ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
@@ -241,42 +310,52 @@ brick:Capacity_Sensor a owl:Class ;
                         owl:hasValue brick:Capacity ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Capacity,
+        tag:Point,
         tag:Sensor .
 
 brick:Centrifugal_Chiller a owl:Class ;
     rdfs:label "Centrifugal Chiller" ;
-    rdfs:subClassOf brick:Chiller .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Centrifugal ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    brick:hasAssociatedTag tag:Centrifugal,
+        tag:Chiller,
+        tag:Equipment .
 
 brick:Change_Filter_Alarm a owl:Class ;
     rdfs:label "Change Filter Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Change ;
                         owl:onProperty brick:hasTag ] _:has_Filter _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Change,
-        tag:Filter .
+        tag:Filter,
+        tag:Point .
 
 brick:Chilled_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
         brick:Chilled_Water_Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Reset,
         tag:Shed,
@@ -285,12 +364,13 @@ brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Setpoint,
         brick:Load_Shed_Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed,
@@ -298,20 +378,21 @@ brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Chilled,
         tag:Differential,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Chilled ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -320,34 +401,37 @@ brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Differential_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Step,
         tag:Water .
 
 brick:Chilled_Water_Differential_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Differential Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Temperature _:has_Sensor ) ],
         brick:Chilled_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Chilled_Water_Discharge_Flow_Sensor a owl:Class ;
     rdfs:label "Chilled Water Discharge Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Discharge _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge _:has_Chilled ) ],
         brick:Discharge_Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -357,6 +441,7 @@ brick:Chilled_Water_Discharge_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -372,15 +457,21 @@ brick:Chilled_Water_Meter a owl:Class ;
 
 brick:Chilled_Water_Pump a owl:Class ;
     rdfs:label "Chilled Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Chilled _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Pump Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Pump _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Pump _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Pump,
         tag:Setpoint,
@@ -388,10 +479,11 @@ brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Chilled_Water_Temperature_Sensor,
         brick:Return_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -399,9 +491,10 @@ brick:Chilled_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Chilled_Water_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -409,7 +502,7 @@ brick:Chilled_Water_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Chilled_Water_Supply_Flow_Sensor a owl:Class ;
     rdfs:label "Chilled Water Supply Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Chilled ) ],
         brick:Supply_Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -418,13 +511,14 @@ brick:Chilled_Water_Supply_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Water .
 
 brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled _:has_Supply ) ],
         brick:Chilled_Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -432,6 +526,7 @@ brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Chilled_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -439,11 +534,12 @@ brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Chilled_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Chilled Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Chilled _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Chilled _:has_Water _:has_System ) ],
         brick:System_Enable_Command ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Command,
         tag:Enable,
+        tag:Point,
         tag:System,
         tag:Water .
 
@@ -468,64 +564,94 @@ brick:City a owl:Class ;
 
 brick:Close_Limit a owl:Class ;
     rdfs:label "Close Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Close ;
                         owl:onProperty brick:hasTag ] _:has_Parameter _:has_Limit ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Close,
         tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Cold_Box a owl:Class ;
     rdfs:label "Cold Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Cold ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Cold,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Communication_Loss_Alarm a owl:Class ;
     rdfs:label "Communication Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Communication ;
                         owl:onProperty brick:hasTag ] _:has_Loss _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Communication,
-        tag:Loss .
+        tag:Loss,
+        tag:Point .
 
 brick:Compressor a owl:Class ;
     rdfs:label "Compressor" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Compressor ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor." ;
+    brick:hasAssociatedTag tag:Compressor,
+        tag:Equipment .
 
 brick:Condensate_Leak_Alarm a owl:Class ;
     rdfs:label "Condensate Leak Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Condensate ;
                         owl:onProperty brick:hasTag ] _:has_Leak _:has_Alarm ) ],
         brick:Leak_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Condensate,
-        tag:Leak .
+        tag:Leak,
+        tag:Point .
 
 brick:Condenser a owl:Class ;
     rdfs:label "Condenser" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Condenser ) ],
+        brick:HVAC ;
+    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase." ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment .
 
 brick:Condenser_Heat_Exchanger a owl:Class ;
     rdfs:label "Condenser Heat Exchanger" ;
-    rdfs:subClassOf brick:Heat_Exchanger .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:Condenser_Water_Pump a owl:Class ;
     rdfs:label "Condenser Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Condenser _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Contact_Sensor a owl:Class ;
     rdfs:label "Contact Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Contact ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     skos:definition "Senses or detects contact, such as for detecting if a door is closed." ;
     brick:hasAssociatedTag tag:Contact,
+        tag:Point,
         tag:Sensor .
 
 brick:Cooling_Coil a owl:Class ;
@@ -538,27 +664,29 @@ brick:Cooling_Coil a owl:Class ;
 
 brick:Cooling_Demand_Setpoint a owl:Class ;
     rdfs:label "Cooling Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Demand,
+        tag:Point,
         tag:Setpoint .
 
 brick:Cooling_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Cooling_Setpoint,
         brick:Discharge_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -566,12 +694,13 @@ brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
 brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Cooling Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -579,61 +708,67 @@ brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class 
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Cooling_On_Off_Status a owl:Class ;
     rdfs:label "Cooling On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Cooling_Request_Percent_Setpoint a owl:Class ;
     rdfs:label "Cooling Request Percent Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Request _:has_Percent _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Request _:has_Percent _:has_Setpoint ) ],
         brick:Cooling_Request_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Percent,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Cooling_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Supply_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Cooling_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time .
 
 brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Cooling Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Cooling,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
@@ -650,7 +785,14 @@ brick:Cooling_Thermal_Power_Meter a owl:Class ;
 
 brick:Cooling_Tower_Fan a owl:Class ;
     rdfs:label "Cooling Tower Fan" ;
-    rdfs:subClassOf brick:Fan .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling [ a owl:Restriction ;
+                        owl:hasValue tag:Tower ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment _:has_Fan ) ],
+        brick:Fan ;
+    brick:hasAssociatedTag tag:Cooling,
+        tag:Equipment,
+        tag:Fan,
+        tag:Tower .
 
 brick:Cooling_Valve a owl:Class ;
     rdfs:label "Cooling Valve" ;
@@ -662,25 +804,27 @@ brick:Cooling_Valve a owl:Class ;
 
 brick:Current_Limit a owl:Class ;
     rdfs:label "Current Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Current _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Current,
         tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Curtailment_Override_Command a owl:Class ;
     rdfs:label "Curtailment Override Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Curtailment ;
                         owl:onProperty brick:hasTag ] _:has_Override _:has_Command ) ],
         brick:Override_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Curtailment,
-        tag:Override .
+        tag:Override,
+        tag:Point .
 
 brick:DC_Bus_Voltage_Sensor a owl:Class ;
     rdfs:label "DC Bus Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dc ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Bus ;
@@ -688,58 +832,64 @@ brick:DC_Bus_Voltage_Sensor a owl:Class ;
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Bus,
         tag:Dc,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
 brick:Damper_Position_Command a owl:Class ;
     rdfs:label "Damper Position Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Command ) ],
         brick:Damper_Command,
         brick:Position_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Damper,
+        tag:Point,
         tag:Position .
 
 brick:Damper_Position_Sensor a owl:Class ;
     rdfs:label "Damper Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Sensor ) ],
         brick:Position_Sensor ;
     brick:hasAssociatedTag tag:Damper,
+        tag:Point,
         tag:Position,
         tag:Sensor .
 
 brick:Damper_Position_Setpoint a owl:Class ;
     rdfs:label "Damper Position Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Position _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Damper,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Deceleration_Time_Setpoint a owl:Class ;
     rdfs:label "Deceleration Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Deceleration ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Time_Setpoint ;
     brick:hasAssociatedTag tag:Deceleration,
+        tag:Point,
         tag:Setpoint,
         tag:Time .
 
 brick:Dehumidification_On_Off_Status a owl:Class ;
     rdfs:label "Dehumidification On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dehumidification ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Dehumidification,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Deionised_Water_Conductivity_Sensor a owl:Class ;
     rdfs:label "Deionised Water Conductivity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Conductivity _:has_Water _:has_Deionised ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity _:has_Water _:has_Deionised ) ],
         brick:Conductivity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Conductivity ;
@@ -748,12 +898,13 @@ brick:Deionised_Water_Conductivity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Conductivity,
         tag:Deionised,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Deionised_Water_Level_Sensor a owl:Class ;
     rdfs:label "Deionised Water Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Water _:has_Level _:has_Deionised ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level _:has_Deionised ) ],
         brick:Water_Level_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Deionized_Water ;
@@ -762,157 +913,198 @@ brick:Deionised_Water_Level_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Deionised,
         tag:Level,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Deionized_Water_Alarm a owl:Class ;
     rdfs:label "Deionized Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Deionized _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deionized _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Deionized,
+        tag:Point,
         tag:Water .
-
-brick:Demand_Sensor a owl:Class ;
-    rdfs:label "Demand Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Demand ) ],
-        brick:Sensor ;
-    brick:hasAssociatedTag tag:Demand,
-        tag:Sensor .
 
 brick:Derivative_Gain_Parameter a owl:Class ;
     rdfs:label "Derivative Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Derivative,
         tag:Gain,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Derivative_Time_Parameter a owl:Class ;
     rdfs:label "Derivative Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Time _:has_Derivative ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Derivative ) ],
         brick:Time_Parameter ;
     brick:hasAssociatedTag tag:Derivative,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Dew_Point_Setpoint a owl:Class ;
     rdfs:label "Dew Point Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Dewpoint _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Dewpoint _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
         tag:Setpoint .
 
 brick:Differential_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Differential Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Differential_Speed_Sensor a owl:Class ;
     rdfs:label "Differential Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Differential ) ],
         brick:Speed_Sensor ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Sensor,
         tag:Speed .
 
 brick:Dimmer a owl:Class ;
     rdfs:label "Dimmer" ;
-    rdfs:subClassOf brick:Switch .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch [ a owl:Restriction ;
+                        owl:hasValue tag:Dimmer ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Switch ;
+    brick:hasAssociatedTag tag:Dimmer,
+        tag:Equipment,
+        tag:Interface,
+        tag:Switch .
 
 brick:Direction_Command a owl:Class ;
     rdfs:label "Direction Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Direction _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Direction .
+        tag:Direction,
+        tag:Point .
 
 brick:Disable_Differential_Enthalpy_Command a owl:Class ;
     rdfs:label "Disable Differential Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Enthalpy ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Disable,
-        tag:Enthalpy .
+        tag:Enthalpy,
+        tag:Point .
 
 brick:Disable_Differential_Temperature_Command a owl:Class ;
     rdfs:label "Disable Differential Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Differential _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Temperature ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Disable,
+        tag:Point,
         tag:Temperature .
 
 brick:Disable_Fixed_Enthalpy_Command a owl:Class ;
     rdfs:label "Disable Fixed Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Enthalpy,
-        tag:Fixed .
+        tag:Fixed,
+        tag:Point .
 
 brick:Disable_Fixed_Temperature_Command a owl:Class ;
     rdfs:label "Disable Fixed Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fixed _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Temperature ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Fixed,
+        tag:Point,
         tag:Temperature .
 
 brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Disable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Outside_Air_Temperature_Setpoint ;
-    skos:definition "Disables hot water system when outside air temperature reaches the indicated value" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Disables hot water system when outside air temperature reaches the indicated value" ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Disable,
+        tag:Hot,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
 
 brick:Disable_Status a owl:Class ;
     rdfs:label "Disable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Disable,
+        tag:Point,
         tag:Status .
 
 brick:Discharge_Air_Duct_Pressure_Status a owl:Class ;
     rdfs:label "Discharge Air Duct Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Duct,
+        tag:Point,
         tag:Pressure,
         tag:Status .
 
 brick:Discharge_Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Demand_Setpoint,
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Discharge_Air_Flow_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset High Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Flow_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Flow_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Flow_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Discharge Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Discharge ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -922,60 +1114,65 @@ brick:Discharge_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Smoke_Detected_Alarm a owl:Class ;
     rdfs:label "Discharge Air Smoke Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Smoke _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Smoke _:has_Detected _:has_Alarm ) ],
         brick:Air_Alarm,
         brick:Smoke_Detected_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Detected,
         tag:Discharge,
+        tag:Point,
         tag:Smoke .
 
 brick:Discharge_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Static_Pressure_Setpoint,
         brick:Static_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Time .
 
 brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Discharge ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -984,42 +1181,63 @@ brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Discharge_Air_Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Air_Static_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
 
 brick:Discharge_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Discharge Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Air_Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
 brick:Discharge_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Discharge Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Discharge _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Discharge _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -1028,6 +1246,7 @@ brick:Discharge_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Velocity .
@@ -1042,52 +1261,56 @@ brick:Discharge_Fan a owl:Class ;
 
 brick:Discharge_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Discharge Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Discharge,
         tag:Fan,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Discharge_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Discharge,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Discharge Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Water_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Discharge,
+        tag:Point,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Water Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Discharge ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1095,25 +1318,28 @@ brick:Discharge_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Discharge_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Discharge_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Discharge Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Domestic_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Domestic Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -1121,11 +1347,12 @@ brick:Domestic_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Domestic_Hot_Water_Supply_Temperature_Setpoint a owl:Class ;
     rdfs:label "Domestic Hot Water Supply Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Domestic_Hot_Water_Temperature_Setpoint,
         brick:Supply_Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature,
@@ -1133,18 +1360,15 @@ brick:Domestic_Hot_Water_Supply_Temperature_Setpoint a owl:Class ;
 
 brick:Domestic_Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Domestic Hot Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Domestic _:has_Hot _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Domestic _:has_Hot _:has_Water _:has_System ) ],
         brick:Hot_Water_System_Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Domestic,
         tag:Enable,
         tag:Hot,
+        tag:Point,
         tag:System,
         tag:Water .
-
-brick:Domestic_Hot_Water_System_Start_Stop_Command a owl:Class ;
-    rdfs:label "Domestic Hot Water System Start Stop Command" ;
-    rdfs:subClassOf brick:Start_Stop_Command .
 
 brick:Domestic_Hot_Water_Valve a owl:Class ;
     rdfs:label "Domestic Hot Water Valve" ;
@@ -1161,48 +1385,50 @@ brick:Domestic_Hot_Water_Valve a owl:Class ;
 
 brick:Drive_Ready_Status a owl:Class ;
     rdfs:label "Drive Ready Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Drive ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Drive [ a owl:Restriction ;
                         owl:hasValue tag:Ready ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Drive,
+        tag:Point,
         tag:Ready,
         tag:Status .
 
 brick:Dual_Band_Mode_Setpoint a owl:Class ;
     rdfs:label "Dual Band Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Dual ;
                         owl:onProperty brick:hasTag ] _:has_Band _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Band,
         tag:Dual,
         tag:Mode,
+        tag:Point,
         tag:Setpoint .
 
 brick:EconCycle_On_Off_Status a owl:Class ;
     rdfs:label "EconCycle On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Econcycle ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Econcycle,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Economizer a owl:Class ;
     rdfs:label "Economizer" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Economizer ) ],
+        brick:HVAC ;
+    skos:definition "Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement." ;
+    brick:hasAssociatedTag tag:Economizer,
+        tag:Equipment .
 
 brick:Economizer_Damper a owl:Class ;
     rdfs:label "Economizer Damper" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper [ a owl:Restriction ;
-                        owl:hasValue tag:Economizer ;
-                        owl:onProperty brick:hasTag ] ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Economizer ) ],
         brick:Damper ;
     brick:hasAssociatedTag tag:Damper,
         tag:Economizer,
@@ -1210,86 +1436,112 @@ brick:Economizer_Damper a owl:Class ;
 
 brick:Effective_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Cooling _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Cooling _:has_Temperature _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Effective_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Effective,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Heating _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Heating _:has_Temperature _:has_Setpoint ) ],
         brick:Effective_Air_Temperature_Setpoint,
         brick:Heating_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Effective,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
-brick:Electrical_Power_Sensor a owl:Class ;
-    rdfs:label "Electrical Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power [ a owl:Restriction ;
-                        owl:hasValue tag:Electrical ;
-                        owl:onProperty brick:hasTag ] ) ],
-        brick:Power_Sensor ;
-    brick:hasAssociatedTag tag:Electrical,
-        tag:Power,
-        tag:Sensor .
-
 brick:Elevator a owl:Class ;
     rdfs:label "Elevator" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Elevator ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Elevator,
+        tag:Equipment .
 
 brick:Emergency_Air_Flow_Status a owl:Class ;
     rdfs:label "Emergency Air Flow Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Air _:has_Flow _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Air _:has_Flow _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Emergency,
         tag:Flow,
+        tag:Point,
         tag:Status .
 
 brick:Emergency_Generator_Alarm a owl:Class ;
     rdfs:label "Emergency Generator Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Generator _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Generator _:has_Emergency _:has_Alarm ) ],
         brick:Emergency_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Emergency,
-        tag:Generator .
+        tag:Generator,
+        tag:Point .
 
 brick:Emergency_Generator_Status a owl:Class ;
     rdfs:label "Emergency Generator Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Generator _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Generator _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:Generator,
+        tag:Point,
         tag:Status .
 
 brick:Emergency_Power_Loss_Alarm a owl:Class ;
     rdfs:label "Emergency Power Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Loss _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Emergency _:has_Alarm ) ],
         brick:Emergency_Alarm,
         brick:Power_Loss_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Emergency,
         tag:Loss,
+        tag:Point,
         tag:Power .
 
 brick:Emergency_Power_Off_Activated_By_High_Temperature_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By High Temperature Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_High _:has_Temperature _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:High,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status,
+        tag:Temperature .
 
 brick:Emergency_Power_Off_Activated_By_Leak_Detection_System_Status a owl:Class ;
     rdfs:label "Emergency Power Off Activated By Leak Detection System Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Leak [ a owl:Restriction ;
+                        owl:hasValue tag:Detection ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Detection,
+        tag:Emergency,
+        tag:Leak,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Power_Off_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off Enable Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Enable,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Power_Off_System a owl:Class ;
     rdfs:label "Emergency Power Off System" ;
@@ -1302,11 +1554,18 @@ brick:Emergency_Power_Off_System a owl:Class ;
 
 brick:Emergency_Power_Off_System_Enable_Status a owl:Class ;
     rdfs:label "Emergency Power Off System Enable Status" ;
-    rdfs:subClassOf brick:Emergency_Power_Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Enable _:has_Status ) ],
+        brick:Emergency_Power_Off_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Enable,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status .
 
 brick:Emergency_Push_Button_Status a owl:Class ;
     rdfs:label "Emergency Push Button Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency [ a owl:Restriction ;
                         owl:hasValue tag:Push ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Button ;
@@ -1314,53 +1573,68 @@ brick:Emergency_Push_Button_Status a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Button,
         tag:Emergency,
+        tag:Point,
         tag:Push,
         tag:Status .
 
 brick:Enable_Differential_Enthalpy_Command a owl:Class ;
     rdfs:label "Enable Differential Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Enthalpy ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Enable,
-        tag:Enthalpy .
+        tag:Enthalpy,
+        tag:Point .
 
 brick:Enable_Differential_Temperature_Command a owl:Class ;
     rdfs:label "Enable Differential Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Differential _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Temperature ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Differential,
         tag:Enable,
+        tag:Point,
         tag:Temperature .
 
 brick:Enable_Fixed_Enthalpy_Command a owl:Class ;
     rdfs:label "Enable Fixed Enthalpy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Enthalpy,
-        tag:Fixed .
+        tag:Fixed,
+        tag:Point .
 
 brick:Enable_Fixed_Temperature_Command a owl:Class ;
     rdfs:label "Enable Fixed Temperature Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fixed _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Temperature ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Fixed,
+        tag:Point,
         tag:Temperature .
 
 brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Enable Hot Water System Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Outside_Air_Temperature_Setpoint ;
-    skos:definition "Enables hot water system when outside air temperature reaches the indicated value" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Enables hot water system when outside air temperature reaches the indicated value" ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enable,
+        tag:Hot,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
 
 brick:Entering_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Entering Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Entering ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Entering ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1368,37 +1642,55 @@ brick:Entering_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Entering_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Entering,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Entering_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Entering Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Entering _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Entering _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Entering,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Enthalpy_Setpoint a owl:Class ;
     rdfs:label "Enthalpy Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Setpoint _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint _:has_Enthalpy ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
         tag:Setpoint .
 
 brick:Environment_Box a owl:Class ;
     rdfs:label "Environment Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Environment ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Environment,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Evaporative_Heat_Exchanger a owl:Class ;
     rdfs:label "Evaporative Heat Exchanger" ;
-    rdfs:subClassOf brick:Heat_Exchanger .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Evaporative ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Evaporative,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:Even_Month_Status a owl:Class ;
     rdfs:label "Even Month Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Even ;
                         owl:onProperty brick:hasTag ] [ a owl:Restriction ;
                         owl:hasValue tag:Month ;
@@ -1406,11 +1698,12 @@ brick:Even_Month_Status a owl:Class ;
         brick:Status ;
     brick:hasAssociatedTag tag:Even,
         tag:Month,
+        tag:Point,
         tag:Status .
 
 brick:Exhaust_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Exhaust ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -1420,23 +1713,25 @@ brick:Exhaust_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Stack_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Flow_Deadband_Setpoint,
         brick:Exhaust_Air_Stack_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Stack .
 
 brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Exhaust_Air_Flow_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
@@ -1444,12 +1739,13 @@ brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Stack,
         tag:Time .
 
 brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Exhaust_Air_Flow_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -1457,45 +1753,49 @@ brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter a owl:Class ;
         tag:Flow,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Stack .
 
 brick:Exhaust_Air_Stack_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Sensor ) ],
         brick:Exhaust_Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Stack .
 
 brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Exhaust,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Exhaust_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Exhaust_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Exhaust ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -1504,12 +1804,13 @@ brick:Exhaust_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Exhaust_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Exhaust _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Exhaust _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -1518,6 +1819,7 @@ brick:Exhaust_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Velocity .
@@ -1540,96 +1842,147 @@ brick:Exhaust_Fan a owl:Class ;
 
 brick:Exhaust_Fan_Disable_Command a owl:Class ;
     rdfs:label "Exhaust Fan Disable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command _:has_Fan _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fan _:has_Exhaust ) ],
         brick:Disable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Disable,
         tag:Exhaust,
-        tag:Fan .
+        tag:Fan,
+        tag:Point .
 
 brick:Exhaust_Fan_Enable_Command a owl:Class ;
     rdfs:label "Exhaust Fan Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Fan _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fan _:has_Exhaust ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Exhaust,
-        tag:Fan .
+        tag:Fan,
+        tag:Point .
 
 brick:Exhaust_Fan_Fire_Control_Panel_Off_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel Off Command" ;
-    rdfs:subClassOf brick:Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_Off _:has_Command ) ],
+        brick:Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Control,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Fire,
+        tag:Off,
+        tag:Panel,
+        tag:Point .
 
 brick:Exhaust_Fan_Fire_Control_Panel_On_Command a owl:Class ;
     rdfs:label "Exhaust Fan Fire Control Panel On Command" ;
-    rdfs:subClassOf brick:On_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Fan _:has_Fire _:has_Control _:has_Panel _:has_On _:has_Command ) ],
+        brick:On_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Control,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Fire,
+        tag:On,
+        tag:Panel,
+        tag:Point .
 
 brick:Fan_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Fan Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Fan,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Fan_Coil_Unit a owl:Class ;
     rdfs:label "Fan Coil Unit" ;
-    rdfs:subClassOf brick:Terminal_Unit ;
-    owl:equivalentClass brick:FCU .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Coil _:has_Unit ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:FCU ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment,
+        tag:Fan,
+        tag:Unit .
 
 brick:Fan_Speed_Reset_Command a owl:Class ;
     rdfs:label "Fan Speed Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Speed_Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fan,
+        tag:Point,
+        tag:Reset,
+        tag:Speed .
 
 brick:Fan_Start_Stop_Status a owl:Class ;
     rdfs:label "Fan Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Start _:has_Stop _:has_Status ) ],
         brick:Fan_Status,
         brick:Start_Stop_Status ;
     brick:hasAssociatedTag tag:Fan,
+        tag:Point,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Fault_Indicator_Status a owl:Class ;
     rdfs:label "Fault Indicator Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Indicator ;
                         owl:onProperty brick:hasTag ] _:has_Fault _:has_Status ) ],
         brick:Fault_Status ;
     brick:hasAssociatedTag tag:Fault,
         tag:Indicator,
+        tag:Point,
         tag:Status .
 
 brick:Fault_Reset_Command a owl:Class ;
     rdfs:label "Fault Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fault,
+        tag:Point,
+        tag:Reset .
 
 brick:Filter_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Filter Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Filter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Filter ) ],
         brick:Differential_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Differential,
         tag:Filter,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
 brick:Filter_Reset_Command a owl:Class ;
     rdfs:label "Filter Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Filter,
+        tag:Point,
+        tag:Reset .
 
 brick:Fire_Control_Panel a owl:Class ;
     rdfs:label "Fire Control Panel" ;
-    rdfs:subClassOf brick:Fire_Safety_System ;
-    owl:equivalentClass brick:FCP .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety _:has_Panel ) ],
+        brick:Fire_Safety_System ;
+    owl:equivalentClass brick:FCP ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Panel,
+        tag:Safety .
 
 brick:Fire_Sensor a owl:Class ;
     rdfs:label "Fire Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Fire ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Fire ) ],
         brick:Sensor ;
     skos:definition "senses or detects fire" ;
     brick:hasAssociatedTag tag:Fire,
+        tag:Point,
         tag:Sensor .
 
 brick:Fire_Zone a owl:Class ;
@@ -1651,63 +2004,75 @@ brick:Floor a owl:Class ;
 
 brick:Freeze_Status a owl:Class ;
     rdfs:label "Freeze Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Freeze ;
-                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Freeze _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Freeze,
+        tag:Point,
         tag:Status .
 
 brick:Freezer a owl:Class ;
     rdfs:label "Freezer" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Freezer ;
+                        owl:onProperty brick:hasTag ] _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Freezer,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Frost_Sensor a owl:Class ;
     rdfs:label "Frost Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Frost ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frost ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Frost ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Frost,
+        tag:Point,
         tag:Sensor .
 
 brick:Fume_Hood a owl:Class ;
     rdfs:label "Fume Hood" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fume _:has_Hood ) ],
+        brick:HVAC ;
+    skos:definition "A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fume,
+        tag:Hood .
 
 brick:Fume_Hood_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Fume Hood Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Fume ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
-                        owl:hasValue tag:Hood ;
-                        owl:onProperty brick:hasTag ] _:has_Air _:has_Flow _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fume _:has_Hood _:has_Air _:has_Flow _:has_Sensor ) ],
         brick:Air_Flow_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Fume,
         tag:Hood,
+        tag:Point,
         tag:Sensor .
 
 brick:Furniture a owl:Class ;
     rdfs:label "Furniture" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Furniture ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Furniture .
 
 brick:Gas_Sensor a owl:Class ;
     rdfs:label "Gas Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Gas ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Gas ) ],
         brick:Sensor ;
     skos:definition "senses or detects gas concentration (other than CO2)" ;
     brick:hasAssociatedTag tag:Gas,
+        tag:Point,
         tag:Sensor .
 
 brick:HVAC_Zone a owl:Class ;
     rdfs:label "HVAC Zone" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:HVAC ;
-                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Location ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_HVAC _:has_Zone _:has_Location ) ],
         brick:Zone ;
     brick:hasAssociatedTag tag:HVAC,
         tag:Location,
@@ -1715,30 +2080,33 @@ brick:HVAC_Zone a owl:Class ;
 
 brick:Hail_Sensor a owl:Class ;
     rdfs:label "Hail Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Hail ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Hail ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Hail ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Hail,
+        tag:Point,
         tag:Sensor .
 
 brick:Hand_Auto_Status a owl:Class ;
     rdfs:label "Hand Auto Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Hand ;
                         owl:onProperty brick:hasTag ] _:has_Auto _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Auto,
         tag:Hand,
+        tag:Point,
         tag:Status .
 
 brick:Heat_Exchanger_Supply_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Heat Exchanger Supply Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Exchanger _:has_Supply _:has_Water _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_Supply _:has_Water _:has_Temperature _:has_Sensor ) ],
         brick:Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Exchanger,
         tag:Heat,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -1746,18 +2114,26 @@ brick:Heat_Exchanger_Supply_Water_Temperature_Sensor a owl:Class ;
 
 brick:Heat_Exchanger_System_Enable_Status a owl:Class ;
     rdfs:label "Heat Exchanger System Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Exchanger _:has_System _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_System _:has_Enable _:has_Status ) ],
         brick:Enable_Status,
         brick:System_Status ;
     brick:hasAssociatedTag tag:Enable,
         tag:Exchanger,
         tag:Heat,
+        tag:Point,
         tag:Status,
         tag:System .
 
 brick:Heat_Wheel_VFD a owl:Class ;
     rdfs:label "Heat Wheel VFD" ;
-    rdfs:subClassOf brick:VFD .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat [ a owl:Restriction ;
+                        owl:hasValue tag:Wheel ;
+                        owl:onProperty brick:hasTag ] _:has_VFD ) ],
+        brick:VFD ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:VFD,
+        tag:Wheel .
 
 brick:Heating_Coil a owl:Class ;
     rdfs:label "Heating Coil" ;
@@ -1769,34 +2145,37 @@ brick:Heating_Coil a owl:Class ;
 
 brick:Heating_Command a owl:Class ;
     rdfs:label "Heating Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Heat .
+        tag:Heat,
+        tag:Point .
 
 brick:Heating_Demand_Setpoint a owl:Class ;
     rdfs:label "Heating Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Demand,
         tag:Heating,
+        tag:Point,
         tag:Setpoint .
 
 brick:Heating_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Deadband_Setpoint,
         brick:Discharge_Air_Temperature_Heating_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -1804,12 +2183,13 @@ brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
 brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Heating Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -1817,61 +2197,67 @@ brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class 
         tag:Heating,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Heating_On_Off_Status a owl:Class ;
     rdfs:label "Heating On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Heating,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Heating_Request_Percent_Setpoint a owl:Class ;
     rdfs:label "Heating Request Percent Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Request _:has_Percent _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Request _:has_Percent _:has_Setpoint ) ],
         brick:Heating_Request_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
         tag:Percent,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Heating_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Supply_Air_Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Heating_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Air_Temperature_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Heating,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time .
 
 brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Heating Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:Heating,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
@@ -1888,108 +2274,134 @@ brick:Heating_Thermal_Power_Meter a owl:Class ;
 
 brick:Heating_Thermal_Power_Sensor a owl:Class ;
     rdfs:label "Heating Thermal Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Sensor _:has_Power _:has_Thermal ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Sensor _:has_Power _:has_Thermal ) ],
         brick:Thermal_Power_Sensor ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Power,
         tag:Sensor,
         tag:Thermal .
 
 brick:High_CO2_Alarm a owl:Class ;
     rdfs:label "High CO2 Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_CO2 _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_CO2 _:has_Alarm ) ],
         brick:CO2_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:CO2,
-        tag:High .
+        tag:High,
+        tag:Point .
 
 brick:High_Discharge_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "High Discharge Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Discharge_Air_Temperature_Alarm,
         brick:High_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Discharge,
         tag:High,
+        tag:Point,
         tag:Temperature .
 
 brick:High_Head_Pressure_Alarm a owl:Class ;
     rdfs:label "High Head Pressure Alarm" ;
-    rdfs:subClassOf brick:Pressure_Alarm .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High [ a owl:Restriction ;
+                        owl:hasValue tag:Head ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Head,
+        tag:High,
+        tag:Point,
+        tag:Pressure .
 
 brick:High_Humidity_Alarm a owl:Class ;
     rdfs:label "High Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm ) ],
         brick:Humidity_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
-        tag:Humidity .
+        tag:Humidity,
+        tag:Point .
 
 brick:High_Humidity_Alarm_Parameter a owl:Class ;
     rdfs:label "High Humidity Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm _:has_Parameter ) ],
         brick:Humidity_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
         tag:Humidity,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:High_Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "High Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Lockout_Temperature_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:High,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:High_Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "High Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:High_Temperature_Alarm,
         brick:Return_Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:High,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
 brick:High_Static_Pressure_Cutout_Setpoint_Limit a owl:Class ;
     rdfs:label "High Static Pressure Cutout Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Static _:has_Pressure [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Static _:has_Pressure [ a owl:Restriction ;
                         owl:hasValue tag:Cutout ;
                         owl:onProperty brick:hasTag ] _:has_Limit _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Cutout,
         tag:High,
         tag:Limit,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:High_Temperature_Alarm_Parameter a owl:Class ;
     rdfs:label "High Temperature Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm _:has_Parameter ) ],
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
         tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
 brick:High_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Return_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "High Temperature Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:High,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -1997,66 +2409,81 @@ brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Highest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Highest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone [ a owl:Restriction ;
-                        owl:hasValue tag:Highest ;
-                        owl:onProperty brick:hasTag ] _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Highest _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     owl:equivalentClass brick:Warmest_Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Highest,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
 
 brick:Highest_Zone_Cooling_Command a owl:Class ;
     rdfs:label "Highest Zone Cooling Command" ;
-    rdfs:subClassOf brick:Cooling_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Highest _:has_Zone _:has_Cool _:has_Command ) ],
+        brick:Cooling_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Cool,
+        tag:Highest,
+        tag:Point,
+        tag:Zone .
 
 brick:Hold_Status a owl:Class ;
     rdfs:label "Hold Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Hold ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Hold,
+        tag:Point,
         tag:Status .
 
 brick:Hot_Box a owl:Class ;
     rdfs:label "Hot Box" ;
-    rdfs:subClassOf brick:Laboratory .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Hot,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Hot_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint,
         brick:Hot_Water_Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
         brick:Hot_Water_Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Reset,
         tag:Shed,
@@ -2065,24 +2492,26 @@ brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:Hot,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Hot_Water_Discharge_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Discharge Temperature Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status,
         tag:Temperature,
@@ -2090,22 +2519,29 @@ brick:Hot_Water_Discharge_Temperature_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Hot Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Hot ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Hot ) ],
         brick:Water_Flow_Sensor ;
     brick:hasAssociatedTag tag:Flow,
         tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Hot_Water_Pump a owl:Class ;
     rdfs:label "Hot Water Pump" ;
-    rdfs:subClassOf brick:Water_Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Hot _:has_Water ) ],
+        brick:Water_Pump ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Pump,
+        tag:Water .
 
 brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Hot Water Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -2113,71 +2549,79 @@ brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Hot_Water_Usage_Sensor a owl:Class ;
     rdfs:label "Hot Water Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Hot _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Hot _:has_Water ) ],
         brick:Water_Usage_Sensor ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Usage,
         tag:Water .
 
 brick:Humidification_On_Off_Status a owl:Class ;
     rdfs:label "Humidification On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Humidification ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Humidification,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Humidifier a owl:Class ;
     rdfs:label "Humidifier" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Humidifier ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Humidifier .
 
 brick:Humidifier_Fault_Status a owl:Class ;
     rdfs:label "Humidifier Fault Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Humidifier ;
-                        owl:onProperty brick:hasTag ] _:has_Fault _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidifier _:has_Fault _:has_Status ) ],
         brick:Fault_Status ;
     brick:hasAssociatedTag tag:Fault,
         tag:Humidifier,
+        tag:Point,
         tag:Status .
 
 brick:Humidify_Command a owl:Class ;
     rdfs:label "Humidify Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Humidify ;
                         owl:onProperty brick:hasTag ] _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Humidify .
+        tag:Humidify,
+        tag:Point .
 
 brick:Humidity_Setpoint a owl:Class ;
     rdfs:label "Humidity Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
         tag:Setpoint .
 
 brick:Humidity_Tolerance_Parameter a owl:Class ;
     rdfs:label "Humidity Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter _:has_Humidity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Humidity ) ],
         brick:Humidity_Parameter,
         brick:Tolerance_Parameter ;
     brick:hasAssociatedTag tag:Humidity,
         tag:Parameter,
+        tag:Point,
         tag:Tolerance .
 
 brick:Ice_Tank_Leaving_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Ice Tank Leaving Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Ice [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ice [ a owl:Restriction ;
                         owl:hasValue tag:Tank ;
                         owl:onProperty brick:hasTag ] _:has_Leaving _:has_Water _:has_Temperature _:has_Sensor ) ],
         brick:Leaving_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Ice,
         tag:Leaving,
+        tag:Point,
         tag:Sensor,
         tag:Tank,
         tag:Temperature,
@@ -2204,7 +2648,7 @@ brick:Isolation_Valve a owl:Class ;
 
 brick:Last_Fault_Code_Status a owl:Class ;
     rdfs:label "Last Fault Code Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Last ;
                         owl:onProperty brick:hasTag ] _:has_Fault [ a owl:Restriction ;
                         owl:hasValue tag:Code ;
@@ -2213,33 +2657,43 @@ brick:Last_Fault_Code_Status a owl:Class ;
     brick:hasAssociatedTag tag:Code,
         tag:Fault,
         tag:Last,
+        tag:Point,
         tag:Status .
 
 brick:Lead_Lag_Command a owl:Class ;
     rdfs:label "Lead Lag Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_Lag _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Lag,
-        tag:Lead .
+        tag:Lead,
+        tag:Point .
 
 brick:Lead_Lag_Status a owl:Class ;
     rdfs:label "Lead Lag Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lead _:has_Lag _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Lag,
         tag:Lead,
+        tag:Point,
         tag:Status .
 
 brick:Lead_On_Off_Command a owl:Class ;
     rdfs:label "Lead On Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Lead,
+        tag:Off,
+        tag:On,
+        tag:Point .
 
 brick:Leaving_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Leaving Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Leaving _:has_Setpoint _:has_Temperature _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leaving _:has_Setpoint _:has_Temperature _:has_Water ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
@@ -2254,208 +2708,256 @@ brick:Lighting_Zone a owl:Class ;
 
 brick:Liquid_Detected_Alarm a owl:Class ;
     rdfs:label "Liquid Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Liquid _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Liquid _:has_Detected _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Detected,
-        tag:Liquid .
+        tag:Liquid,
+        tag:Point .
 
 brick:Load_Current_Sensor a owl:Class ;
     rdfs:label "Load Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Current _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Current _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Load,
+        tag:Point,
         tag:Sensor .
 
 brick:Locally_On_Off_Status a owl:Class ;
     rdfs:label "Locally On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Locally ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Locally,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Lockout_Command a owl:Class ;
     rdfs:label "Lockout Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lockout _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lockout _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Lockout .
+        tag:Lockout,
+        tag:Point .
 
 brick:Low_Freeze_Protect_Temperature_Parameter a owl:Class ;
     rdfs:label "Low Freeze Protect Temperature Parameter" ;
-    rdfs:subClassOf brick:Temperature_Parameter .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Freeze [ a owl:Restriction ;
+                        owl:hasValue tag:Protect ;
+                        owl:onProperty brick:hasTag ] _:has_Temperature _:has_Parameter ) ],
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Freeze,
+        tag:Low,
+        tag:Parameter,
+        tag:Point,
+        tag:Protect,
+        tag:Temperature .
 
 brick:Low_Humidity_Alarm a owl:Class ;
     rdfs:label "Low Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm ) ],
         brick:Humidity_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Humidity,
-        tag:Low .
+        tag:Low,
+        tag:Point .
 
 brick:Low_Humidity_Alarm_Parameter a owl:Class ;
     rdfs:label "Low Humidity Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm _:has_Parameter ) ],
         brick:Humidity_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Humidity,
         tag:Low,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Low_Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "Low Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Lockout_Temperature_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Lockout,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Low_Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
     rdfs:label "Low Outside Air Temperature Enable Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Enable_Differential_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Enable,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Low_Outside_Air_Temperature_Enable_Setpoint a owl:Class ;
     rdfs:label "Low Outside Air Temperature Enable Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Enable,
         tag:Low,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Low_Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Low Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Low_Temperature_Alarm,
         brick:Return_Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Low,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
 brick:Low_Suction_Pressure_Alarm a owl:Class ;
     rdfs:label "Low Suction Pressure Alarm" ;
-    rdfs:subClassOf brick:Pressure_Alarm .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low [ a owl:Restriction ;
+                        owl:hasValue tag:Suction ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Low,
+        tag:Point,
+        tag:Pressure,
+        tag:Suction .
 
 brick:Low_Temperature_Alarm_Parameter a owl:Class ;
     rdfs:label "Low Temperature Alarm Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm _:has_Parameter ) ],
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Low,
         tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
 brick:Lowest_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Lowest Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lowest _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lowest _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
         brick:Exhaust_Air_Static_Pressure_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Lowest,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Lowest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Lowest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Zone _:has_Lowest _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Lowest _:has_Air ) ],
         brick:Zone_Air_Temperature_Sensor ;
     owl:equivalentClass brick:Coldest_Zone_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Lowest,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
 
 brick:Luminaire a owl:Class ;
     rdfs:label "Luminaire" ;
-    rdfs:subClassOf brick:Lighting .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire _:has_Equipment ) ],
+        brick:Lighting ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Luminaire .
 
 brick:Luminaire_Driver a owl:Class ;
     rdfs:label "Luminaire Driver" ;
-    rdfs:subClassOf brick:Lighting .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire [ a owl:Restriction ;
+                        owl:hasValue tag:Driver ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Lighting ;
+    brick:hasAssociatedTag tag:Driver,
+        tag:Equipment,
+        tag:Luminaire .
 
 brick:Luminance_Alarm a owl:Class ;
     rdfs:label "Luminance Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Luminance .
+        tag:Luminance,
+        tag:Point .
 
 brick:Luminance_Command a owl:Class ;
     rdfs:label "Luminance Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Luminance .
+        tag:Luminance,
+        tag:Point .
 
 brick:Luminance_Sensor a owl:Class ;
     rdfs:label "Luminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Luminance ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Luminance ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Luminance ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
         tag:Sensor .
 
 brick:Luminance_Setpoint a owl:Class ;
     rdfs:label "Luminance Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminance _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
         tag:Setpoint .
 
 brick:Maintenance_Mode_Command a owl:Class ;
     rdfs:label "Maintenance Mode Command" ;
-    rdfs:subClassOf brick:Mode_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Maintenance,
+        tag:Mode,
+        tag:Point .
 
 brick:Maintenance_Required_Alarm a owl:Class ;
     rdfs:label "Maintenance Required Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Maintenance ;
-                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance [ a owl:Restriction ;
                         owl:hasValue tag:Required ;
                         owl:onProperty brick:hasTag ] _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Maintenance,
+        tag:Point,
         tag:Required .
 
 brick:Manual_Auto_Status a owl:Class ;
     rdfs:label "Manual Auto Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Manual ;
                         owl:onProperty brick:hasTag ] _:has_Auto _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Auto,
         tag:Manual,
+        tag:Point,
         tag:Status .
 
 brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Chilled Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Chilled,
@@ -2463,13 +2965,14 @@ brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Discharge Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Max_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -2477,33 +2980,36 @@ brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Max_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint_Limit,
         brick:Max_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Max_Frequency_Command a owl:Class ;
     rdfs:label "Max Frequency Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Fequency _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Fequency _:has_Command ) ],
         brick:Frequency_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Fequency,
-        tag:Max .
+        tag:Max,
+        tag:Point .
 
 brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Hot Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Differential,
@@ -2511,22 +3017,24 @@ brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Max_Load_Setpoint a owl:Class ;
     rdfs:label "Max Load Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Load _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Load _:has_Parameter _:has_Setpoint ) ],
         brick:Load_Parameter ;
     brick:hasAssociatedTag tag:Load,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2536,11 +3044,12 @@ brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2549,12 +3058,13 @@ brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2564,11 +3074,12 @@ brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Occupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2577,49 +3088,54 @@ brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Max,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Position_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Position Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Position _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Position _:has_Limit _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Position_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Max_Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Max Return Air CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
         brick:Return_Air_CO2_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
         tag:Max,
+        tag:Point,
         tag:Return,
         tag:Setpoint .
 
 brick:Max_Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Speed_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Supply Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Max_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -2627,7 +3143,7 @@ brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
 
 brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2636,12 +3152,13 @@ brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2649,13 +3166,14 @@ brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2664,12 +3182,13 @@ brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Unoccupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2677,60 +3196,157 @@ brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Reset Status" ;
-    rdfs:subClassOf brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+        brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Reset,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Setpoint" ;
-    rdfs:subClassOf brick:Load_Shed_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Differential_Pressure_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+        brick:Hot_Water_Differential_Pressure_Sensor ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint,
-        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Discharge Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf brick:Hot_Water_Return_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint,
-        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Setpoint" ;
-    rdfs:subClassOf brick:Load_Shed_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Status" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Hot_Water_Supply_Temperature_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Shed,
+        tag:Status,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Medium ;
-                        owl:onProperty brick:hasTag ] _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
         brick:Hot_Water_Supply_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
         tag:Medium,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -2738,7 +3354,7 @@ brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
 
 brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Chilled Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Chilled,
@@ -2746,13 +3362,14 @@ brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Discharge Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Min_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -2760,36 +3377,39 @@ brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Min_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint_Limit,
         brick:Min_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Min_Fresh_Air_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Fresh Air Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
         brick:Fresh_Air_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Fresh,
         tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Hot Water Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Differential,
@@ -2797,13 +3417,14 @@ brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2813,11 +3434,12 @@ brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2826,12 +3448,13 @@ brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2841,11 +3464,12 @@ brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Occupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2854,12 +3478,13 @@ brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Occupied,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Outside_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Outside Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Outside _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Outside _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2867,38 +3492,42 @@ brick:Min_Outside_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Min,
         tag:Outside,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Position_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Position Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Position _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Position _:has_Limit _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Position_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Position,
         tag:Setpoint .
 
 brick:Min_Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Speed_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Supply Air Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Min_Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -2906,7 +3535,7 @@ brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
 
 brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2915,12 +3544,13 @@ brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -2928,13 +3558,14 @@ brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -2943,12 +3574,13 @@ brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Unoccupied Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -2956,17 +3588,23 @@ brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Unoccupied .
 
 brick:Mixed_Air_Filter a owl:Class ;
     rdfs:label "Mixed Air Filter" ;
-    rdfs:subClassOf brick:Filter .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Mixed _:has_Air _:has_Filter ) ],
+        brick:Filter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Filter,
+        tag:Mixed .
 
 brick:Mixed_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Mixed Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Mixed ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Mixed ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -2975,90 +3613,100 @@ brick:Mixed_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Mixed,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Mixed_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Mixed Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mixed _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mixed _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Mixed,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Monthly_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Monthly Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Monthly ;
                         owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
     brick:hasAssociatedTag tag:Monthly,
+        tag:Point,
         tag:Sensor,
         tag:Steam,
         tag:Usage .
 
 brick:Motor_Current_Sensor a owl:Class ;
     rdfs:label "Motor Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Current _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Current _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Motor,
+        tag:Point,
         tag:Sensor .
 
 brick:Motor_Direction_Status a owl:Class ;
     rdfs:label "Motor Direction Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Direction _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Direction _:has_Status ) ],
         brick:Direction_Status ;
     brick:hasAssociatedTag tag:Direction,
         tag:Motor,
+        tag:Point,
         tag:Status .
 
 brick:Motor_Speed_Sensor a owl:Class ;
     rdfs:label "Motor Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Speed _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Speed _:has_Sensor ) ],
         brick:Speed_Sensor ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Sensor,
         tag:Speed .
 
 brick:Motor_Start_Stop_Status a owl:Class ;
     rdfs:label "Motor Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Start _:has_Stop _:has_Status ) ],
         brick:Start_Stop_Status ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Motor_Torque_Sensor a owl:Class ;
     rdfs:label "Motor Torque Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Motor _:has_Torque _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Torque _:has_Sensor ) ],
         brick:Torque_Sensor ;
     brick:hasAssociatedTag tag:Motor,
+        tag:Point,
         tag:Sensor,
         tag:Torque .
 
 brick:No_Water_Alarm a owl:Class ;
     rdfs:label "No Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:No ;
                         owl:onProperty brick:hasTag ] _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:No,
+        tag:Point,
         tag:Water .
 
 brick:Occupancy_Command a owl:Class ;
     rdfs:label "Occupancy Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupancy _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Occupancy .
+        tag:Occupancy,
+        tag:Point .
 
 brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Cooling_Discharge_Air_Flow_Setpoint,
         brick:Occupied_Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
@@ -3066,34 +3714,37 @@ brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Discharge,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Cooling_Supply_Air_Flow_Setpoint,
         brick:Occupied_Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Occupied_Cooling_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Occupied Cooling Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Cooling _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cooling _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
         tag:Deadband,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Occupied_Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Heating_Discharge_Air_Flow_Setpoint,
         brick:Occupied_Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
@@ -3101,60 +3752,66 @@ brick:Occupied_Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
         tag:Flow,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Heating_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Heating_Supply_Air_Flow_Setpoint,
         brick:Occupied_Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Occupied_Heating_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Occupied Heating Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Heating _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heating _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Heating,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Occupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Occupied Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Mode,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Mode_Status a owl:Class ;
     rdfs:label "Occupied Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Mode _:has_Status ) ],
         brick:Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Occupied,
+        tag:Point,
         tag:Status .
 
 brick:On_Timer_Sensor a owl:Class ;
     rdfs:label "On Timer Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On [ a owl:Restriction ;
                         owl:hasValue tag:Timer ;
                         owl:onProperty brick:hasTag ] _:has_Sensor ) ],
         brick:Duration_Sensor ;
     brick:hasAssociatedTag tag:On,
+        tag:Point,
         tag:Sensor,
         tag:Timer .
 
 brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Open Heating Valve Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Open ;
                         owl:onProperty brick:hasTag ] _:has_Heating _:has_Valve _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
@@ -3163,23 +3820,26 @@ brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
         tag:Heating,
         tag:Open,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Valve .
 
 brick:Output_Frequency_Sensor a owl:Class ;
     rdfs:label "Output Frequency Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Output _:has_Frequency _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Frequency _:has_Sensor ) ],
         brick:Frequency_Sensor ;
     brick:hasAssociatedTag tag:Frequency,
         tag:Output,
+        tag:Point,
         tag:Sensor .
 
 brick:Output_Voltage_Sensor a owl:Class ;
     rdfs:label "Output Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Output _:has_Voltage _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Voltage _:has_Sensor ) ],
         brick:Voltage_Sensor ;
     brick:hasAssociatedTag tag:Output,
+        tag:Point,
         tag:Sensor,
         tag:Voltage .
 
@@ -3192,7 +3852,7 @@ brick:Outside a owl:Class ;
 
 brick:Outside_Air_CO2_Sensor a owl:Class ;
     rdfs:label "Outside Air CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_CO2 _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_CO2 _:has_Sensor ) ],
         brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Outside_Air ;
@@ -3202,11 +3862,12 @@ brick:Outside_Air_CO2_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Dewpoint_Sensor a owl:Class ;
     rdfs:label "Outside Air Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Outside ) ],
         brick:Dewpoint_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
@@ -3216,11 +3877,12 @@ brick:Outside_Air_Dewpoint_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Dewpoint,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Outside Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Air_Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -3230,11 +3892,12 @@ brick:Outside_Air_Enthalpy_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Outside Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Outside ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -3244,20 +3907,22 @@ brick:Outside_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Outside Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Outside,
+        tag:Point,
         tag:Setpoint .
 
 brick:Outside_Air_Grains_Sensor a owl:Class ;
     rdfs:label "Outside Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Grains _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Grains _:has_Sensor ) ],
         brick:Air_Grains_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Outside_Air ;
@@ -3267,11 +3932,12 @@ brick:Outside_Air_Grains_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Outside Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Outside ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -3281,25 +3947,43 @@ brick:Outside_Air_Humidity_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Outside_Air_Lockout_Temperature_Setpoint a owl:Class ;
     rdfs:label "Outside Air Lockout Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Setpoint ) ],
         brick:Outside_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Outside_Air_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Outside,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Outside_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Low_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Outside,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Outside_Damper a owl:Class ;
     rdfs:label "Outside Damper" ;
@@ -3311,53 +3995,73 @@ brick:Outside_Damper a owl:Class ;
 
 brick:Outside_Illuminance_Sensor a owl:Class ;
     rdfs:label "Outside Illuminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Illuminance _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance _:has_Outside ) ],
         brick:Illuminance_Sensor ;
     brick:hasAssociatedTag tag:Illuminance,
         tag:Outside,
+        tag:Point,
         tag:Sensor .
 
 brick:Overload_Alarm a owl:Class ;
     rdfs:label "Overload Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Overload ;
                         owl:onProperty brick:hasTag ] _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Overload .
+        tag:Overload,
+        tag:Point .
 
 brick:Overridden_Off_Status a owl:Class ;
     rdfs:label "Overridden Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:Overridden_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:Overridden,
+        tag:Point,
         tag:Status .
 
 brick:Overridden_On_Status a owl:Class ;
     rdfs:label "Overridden On Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_On _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_On _:has_Status ) ],
         brick:On_Status,
         brick:Overridden_Status ;
     brick:hasAssociatedTag tag:On,
         tag:Overridden,
+        tag:Point,
         tag:Status .
 
 brick:PIR_Sensor a owl:Class ;
     rdfs:label "PIR Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:PIR ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Motion_Sensor,
         brick:Occupancy_Sensor ;
     brick:hasAssociatedTag tag:PIR,
         tag:Pir,
+        tag:Point,
+        tag:Sensor .
+
+brick:Peak_Power_Demand_Sensor a owl:Class ;
+    rdfs:label "Peak Power Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Peak _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
+        brick:Demand_Sensor,
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Peak_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Electrical,
+        tag:Peak,
+        tag:Point,
+        tag:Power,
         tag:Sensor .
 
 brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     rdfs:label "Photovoltaic Current Output Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Photovoltaic ;
                         owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
         brick:Current_Output_Sensor ;
@@ -3365,15 +4069,17 @@ brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Current,
         tag:Output,
         tag:Photovoltaic,
+        tag:Point,
         tag:Sensor .
 
 brick:Piezoelectric_Sensor a owl:Class ;
     rdfs:label "Piezoelectric Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Piezoelectric ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Piezoelectric,
+        tag:Point,
         tag:Sensor .
 
 brick:PlugStrip a owl:Class ;
@@ -3387,28 +4093,31 @@ brick:PlugStrip a owl:Class ;
 
 brick:Pre_Filter_Status a owl:Class ;
     rdfs:label "Pre Filter Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Pre ;
                         owl:onProperty brick:hasTag ] _:has_Filter _:has_Status ) ],
         brick:Filter_Status ;
     brick:hasAssociatedTag tag:Filter,
+        tag:Point,
         tag:Pre,
         tag:Status .
 
 brick:Preheat_Demand_Setpoint a owl:Class ;
     rdfs:label "Preheat Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Demand _:has_Setpoint ) ],
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Demand,
+        tag:Point,
         tag:Preheat,
         tag:Setpoint .
 
 brick:Preheat_Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Preheat Discharge Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Discharge _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Discharge _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Discharge_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Preheat,
         tag:Sensor,
         tag:Temperature .
@@ -3428,9 +4137,10 @@ brick:Preheat_Hot_Water_Valve a owl:Class ;
 
 brick:Preheat_Supply_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Preheat Supply Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Supply _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Supply _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Supply_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Preheat,
         tag:Sensor,
         tag:Supply,
@@ -3438,48 +4148,69 @@ brick:Preheat_Supply_Air_Temperature_Sensor a owl:Class ;
 
 brick:Preheat_Valve_VFD a owl:Class ;
     rdfs:label "Preheat Valve VFD" ;
-    rdfs:subClassOf brick:VFD .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Preheat _:has_VFD ) ],
+        brick:VFD ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Preheat,
+        tag:VFD .
 
 brick:Pump_Command a owl:Class ;
     rdfs:label "Pump Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pump _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Pump .
 
 brick:Pump_Start_Stop_Status a owl:Class ;
     rdfs:label "Pump Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pump _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_Start _:has_Stop _:has_Status ) ],
         brick:Start_Stop_Status ;
-    brick:hasAssociatedTag tag:Pump,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pump,
         tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Rain_Duration_Sensor a owl:Class ;
     rdfs:label "Rain Duration Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Rain _:has_Duration ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain _:has_Duration ) ],
         brick:Duration_Sensor,
         brick:Rain_Sensor ;
     brick:hasAssociatedTag tag:Duration,
+        tag:Point,
         tag:Rain,
         tag:Sensor .
 
 brick:Rated_Speed_Setpoint a owl:Class ;
     rdfs:label "Rated Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Rated ;
                         owl:onProperty brick:hasTag ] _:has_Speed _:has_Setpoint ) ],
         brick:Speed_Setpoint ;
-    brick:hasAssociatedTag tag:Rated,
+    brick:hasAssociatedTag tag:Point,
+        tag:Rated,
         tag:Setpoint,
         tag:Speed .
 
+brick:Reactive_Power_Sensor a owl:Class ;
+    rdfs:label "Reactive Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Reactive ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Reactive_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
+        tag:Reactive,
+        tag:Sensor .
+
 brick:Reheat_Valve a owl:Class ;
     rdfs:label "Reheat Valve" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve [ a owl:Restriction ;
-                        owl:hasValue tag:Reheat ;
-                        owl:onProperty brick:hasTag ] _:has_Heat _:has_Equipment ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Reheat _:has_Heat _:has_Equipment ) ],
         brick:Heating_Valve ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Heat,
@@ -3488,7 +4219,7 @@ brick:Reheat_Valve a owl:Class ;
 
 brick:Relative_Humidity_Sensor a owl:Class ;
     rdfs:label "Relative Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air [ a owl:Restriction ;
                         owl:hasValue tag:Relative ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Air_Humidity_Sensor ;
@@ -3499,23 +4230,25 @@ brick:Relative_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Relative,
         tag:Sensor .
 
 brick:Remotely_On_Off_Status a owl:Class ;
     rdfs:label "Remotely On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Remotely ;
                         owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Remotely,
         tag:Status .
 
 brick:Return_Air_CO2_Sensor a owl:Class ;
     rdfs:label "Return Air CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_CO2 _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Sensor ) ],
         brick:CO2_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Return_Air ;
@@ -3524,12 +4257,13 @@ brick:Return_Air_CO2_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Dewpoint_Sensor a owl:Class ;
     rdfs:label "Return Air Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Return ) ],
         brick:Dewpoint_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
@@ -3538,12 +4272,13 @@ brick:Return_Air_Dewpoint_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Dewpoint,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Return Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Air_Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -3552,12 +4287,13 @@ brick:Return_Air_Enthalpy_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Return Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Return ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -3566,12 +4302,13 @@ brick:Return_Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Grains_Sensor a owl:Class ;
     rdfs:label "Return Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Grains _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Grains _:has_Sensor ) ],
         brick:Air_Grains_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Return_Air ;
@@ -3580,12 +4317,13 @@ brick:Return_Air_Grains_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Return Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Return ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -3594,12 +4332,13 @@ brick:Return_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Return,
         tag:Sensor .
 
 brick:Return_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Return Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Return ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -3607,6 +4346,7 @@ brick:Return_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Return_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature .
@@ -3629,10 +4369,11 @@ brick:Return_Fan a owl:Class ;
 
 brick:Return_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Return Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Fan,
+        tag:Point,
         tag:Return,
         tag:Setpoint,
         tag:Speed .
@@ -3658,80 +4399,92 @@ brick:Roof a owl:Class ;
 
 brick:Room_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Room Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Room ;
-                        owl:onProperty brick:hasTag ] _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Room,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Run_Enable_Command a owl:Class ;
     rdfs:label "Run Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Run ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Run ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:Run .
 
 brick:Run_Enable_Status a owl:Class ;
     rdfs:label "Run Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Enable _:has_Status ) ],
         brick:Enable_Status,
         brick:Run_Status ;
     brick:hasAssociatedTag tag:Enable,
+        tag:Point,
         tag:Run,
         tag:Status .
 
 brick:Run_Request_Command a owl:Class ;
     rdfs:label "Run Request Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Request _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Request _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Request,
         tag:Run .
 
 brick:Run_Request_Status a owl:Class ;
     rdfs:label "Run Request Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Request _:has_Run _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Request _:has_Run _:has_Status ) ],
         brick:Run_Status ;
-    brick:hasAssociatedTag tag:Request,
+    brick:hasAssociatedTag tag:Point,
+        tag:Request,
         tag:Run,
         tag:Status .
 
 brick:Run_Time_Sensor a owl:Class ;
     rdfs:label "Run Time Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Time _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Time _:has_Sensor ) ],
         brick:Duration_Sensor ;
-    brick:hasAssociatedTag tag:Run,
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
         tag:Sensor,
         tag:Time .
 
 brick:Sash_Position_Sensor a owl:Class ;
     rdfs:label "Sash Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Sash ;
                         owl:onProperty brick:hasTag ] _:has_Position _:has_Sensor ) ],
         brick:Position_Sensor ;
-    brick:hasAssociatedTag tag:Position,
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
         tag:Sash,
         tag:Sensor .
 
 brick:Schedule_Temperature_Setpoint a owl:Class ;
     rdfs:label "Schedule Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
                         owl:hasValue tag:Schedule ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Temperature_Setpoint ;
     skos:definition "The current setpoint as indicated by the schedule" ;
-    brick:hasAssociatedTag tag:Schedule,
+    brick:hasAssociatedTag tag:Point,
+        tag:Schedule,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Server_Room a owl:Class ;
     rdfs:label "Server Room" ;
-    rdfs:subClassOf brick:Room .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Server ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Location ) ],
+        brick:Room ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Server .
 
 brick:Shading_System a owl:Class ;
     rdfs:label "Shading System" ;
@@ -3744,22 +4497,24 @@ brick:Shading_System a owl:Class ;
 
 brick:Short_Cycle_Alarm a owl:Class ;
     rdfs:label "Short Cycle Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Short ;
                         owl:onProperty brick:hasTag ] _:has_Cycle _:has_Alarm ) ],
         brick:Cycle_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Cycle,
+        tag:Point,
         tag:Short .
 
 brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
     rdfs:label "Solar Azimuth Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solar [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
                         owl:hasValue tag:Azimuth ;
                         owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
         brick:Angle_Sensor ;
     brick:hasAssociatedTag tag:Angle,
         tag:Azimuth,
+        tag:Point,
         tag:Sensor,
         tag:Solar .
 
@@ -3772,60 +4527,64 @@ brick:Solar_Panel a owl:Class ;
 
 brick:Solar_Radiance_Sensor a owl:Class ;
     rdfs:label "Solar Radiance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Radiance ;
                         owl:onProperty brick:hasTag ] _:has_Solar ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Solar_Radiance ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Radiance,
+    brick:hasAssociatedTag tag:Point,
+        tag:Radiance,
         tag:Sensor,
         tag:Solar .
 
 brick:Solar_Zenith_Angle_Sensor a owl:Class ;
     rdfs:label "Solar Zenith Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solar [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
                         owl:hasValue tag:Zenith ;
                         owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
         brick:Angle_Sensor ;
     brick:hasAssociatedTag tag:Angle,
+        tag:Point,
         tag:Sensor,
         tag:Solar,
         tag:Zenith .
 
 brick:Space a owl:Class ;
     rdfs:label "Space" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Space ;
-                        owl:onProperty brick:hasTag ] _:has_Location ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Space _:has_Location ) ],
         brick:Location ;
     brick:hasAssociatedTag tag:Location,
         tag:Space .
 
 brick:Space_Heater a owl:Class ;
     rdfs:label "Space Heater" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A heater used to warm the air in an enclosed area, such as a room or office" .
-
-brick:Speed_Reset_Command a owl:Class ;
-    rdfs:label "Speed Reset Command" ;
-    rdfs:subClassOf brick:Reset_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Space [ a owl:Restriction ;
+                        owl:hasValue tag:Heater ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "A heater used to warm the air in an enclosed area, such as a room or office" ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heater,
+        tag:Space .
 
 brick:Speed_Status a owl:Class ;
     rdfs:label "Speed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Speed,
+    brick:hasAssociatedTag tag:Point,
+        tag:Speed,
         tag:Status .
 
 brick:Stages_Status a owl:Class ;
     rdfs:label "Stages Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Stages ;
                         owl:onProperty brick:hasTag ] _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Stages,
+    brick:hasAssociatedTag tag:Point,
+        tag:Stages,
         tag:Status .
 
 brick:Standby_Fan a owl:Class ;
@@ -3838,20 +4597,36 @@ brick:Standby_Fan a owl:Class ;
 
 brick:Standby_Glycool_Unit_On_Off_Status a owl:Class ;
     rdfs:label "Standby Glycool Unit On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby [ a owl:Restriction ;
                         owl:hasValue tag:Glycool ;
                         owl:onProperty brick:hasTag ] _:has_Unit _:has_On _:has_Off _:has_Status ) ],
         brick:Standby_Unit_On_Off_Status ;
     brick:hasAssociatedTag tag:Glycool,
         tag:Off,
         tag:On,
+        tag:Point,
         tag:Standby,
         tag:Status,
         tag:Unit .
 
+brick:Start_Stop_Command a owl:Class ;
+    rdfs:label "Start Stop Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Start,
+        tag:Stop .
+
 brick:Steam_On_Off_Command a owl:Class ;
     rdfs:label "Steam On Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Steam _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Steam .
 
 brick:Steam_System a owl:Class ;
     rdfs:label "Steam System" ;
@@ -3862,28 +4637,30 @@ brick:Steam_System a owl:Class ;
 
 brick:Supply_Air_Duct_Pressure_Status a owl:Class ;
     rdfs:label "Supply Air Duct Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Air,
         tag:Duct,
+        tag:Point,
         tag:Pressure,
         tag:Status,
         tag:Supply .
 
 brick:Supply_Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Supply Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Demand_Setpoint,
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Supply_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Supply Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Supply ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -3892,38 +4669,42 @@ brick:Supply_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Supply_Air_Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Supply Air Integral Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Integral _:has_Gain _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Integral _:has_Gain _:has_Parameter _:has_PID ) ],
         brick:Integral_Gain_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Gain,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply .
 
 brick:Supply_Air_Proportional_Gain_Parameter a owl:Class ;
     rdfs:label "Supply Air Proportional Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Proportional _:has_Supply _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional _:has_Supply _:has_Air ) ],
         brick:Proportional_Gain_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Gain,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply .
 
 brick:Supply_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Air Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Static_Pressure_Deadband_Setpoint,
         brick:Supply_Air_Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -3931,12 +4712,13 @@ brick:Supply_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Air Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Supply,
@@ -3944,12 +4726,13 @@ brick:Supply_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Air Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Static_Pressure_Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static,
@@ -3957,7 +4740,7 @@ brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
 
 brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Supply Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Supply ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -3965,6 +4748,7 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static,
@@ -3972,34 +4756,64 @@ brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
 
 brick:Supply_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Supply Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Temperature_Reset_High_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset High Setpoint" ;
-    rdfs:subClassOf brick:Supply_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
 
 brick:Supply_Air_Temperature_Reset_Low_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Reset Low Setpoint" ;
-    rdfs:subClassOf brick:Supply_Air_Temperature_Reset_Differential_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
 
 brick:Supply_Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Supply Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Air_Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Supply Air Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity _:has_Supply _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Supply _:has_Air ) ],
         brick:Velocity_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
@@ -4007,6 +4821,7 @@ brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Supply,
@@ -4014,23 +4829,25 @@ brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
 
 brick:Supply_Fan_Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Supply Fan Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Fan _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Differential_Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Fan,
+        tag:Point,
         tag:Setpoint,
         tag:Speed,
         tag:Supply .
 
 brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Integral_Time_Parameter,
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Supply,
         tag:Time,
@@ -4038,19 +4855,21 @@ brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Supply Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Water_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Water .
 
 brick:Supply_Water_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Water Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Supply_Water_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature,
@@ -4058,12 +4877,13 @@ brick:Supply_Water_Temperature_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Water_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Supply Water Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Supply,
         tag:Temperature,
         tag:Time,
@@ -4071,12 +4891,13 @@ brick:Supply_Water_Temperature_Integral_Time_Parameter a owl:Class ;
 
 brick:Supply_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Water Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature,
@@ -4084,57 +4905,63 @@ brick:Supply_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
 
 brick:System_Mode_Status a owl:Class ;
     rdfs:label "System Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Mode _:has_Status ) ],
         brick:Mode_Status,
         brick:System_Status ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Status,
         tag:System .
 
 brick:System_Shutdown_Status a owl:Class ;
     rdfs:label "System Shutdown Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Shutdown _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Shutdown _:has_Status ) ],
         brick:Status,
         brick:System_Status ;
-    brick:hasAssociatedTag tag:Shutdown,
+    brick:hasAssociatedTag tag:Point,
+        tag:Shutdown,
         tag:Status,
         tag:System .
 
 brick:Temperature_Adjust_Sensor a owl:Class ;
     rdfs:label "Temperature Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust _:has_Temperature ) ],
         brick:Adjust_Sensor ;
     brick:hasAssociatedTag tag:Adjust,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Temperature_Tolerance_Parameter a owl:Class ;
     rdfs:label "Temperature Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Temperature ) ],
         brick:Temperature_Parameter,
         brick:Tolerance_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Tolerance .
 
 brick:Temporary_Occupancy_Status a owl:Class ;
     rdfs:label "Temporary Occupancy Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Temporary ;
                         owl:onProperty brick:hasTag ] _:has_Occupancy _:has_Status ) ],
         brick:Occupancy_Status ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Status,
         tag:Temporary .
 
 brick:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Thermal Energy Storage Discharge Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Thermal _:has_Energy _:has_Storage _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Thermal _:has_Energy _:has_Storage _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Discharge,
         tag:Energy,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Storage,
@@ -4143,11 +4970,12 @@ brick:Thermal_Energy_Storage_Discharge_Water_Differential_Pressure_Deadband_Setp
 
 brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Thermal Energy Storage Supply Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Thermal _:has_Energy _:has_Storage _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Thermal _:has_Energy _:has_Storage _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Supply_Water_Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Energy,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Storage,
@@ -4157,171 +4985,241 @@ brick:Thermal_Energy_Storage_Supply_Water_Differential_Pressure_Deadband_Setpoin
 
 brick:Thermostat a owl:Class ;
     rdfs:label "Thermostat" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "An automatic control device used to maintain temperature at a fixed or adjustable setpoint." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Thermostat ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    skos:definition "An automatic control device used to maintain temperature at a fixed or adjustable setpoint." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Thermostat .
 
 brick:Today_Peak_Energy_Sensor a owl:Class ;
     rdfs:label "Today Peak Energy Sensor" ;
-    rdfs:subClassOf brick:Energy_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy _:has_Today _:has_Peak ) ],
+        brick:Energy_Sensor ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Peak,
+        tag:Point,
+        tag:Sensor,
+        tag:Today .
 
 brick:Today_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Today Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Today ;
-                        owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Today _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Today,
         tag:Usage .
 
 brick:Touchpanel a owl:Class ;
     rdfs:label "Touchpanel" ;
-    rdfs:subClassOf brick:Interface .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface [ a owl:Restriction ;
+                        owl:hasValue tag:Touchpanel ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Interface ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Touchpanel .
 
 brick:Trace_Heat_Sensor a owl:Class ;
     rdfs:label "Trace Heat Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Trace ;
                         owl:onProperty brick:hasTag ] _:has_Heat _:has_Sensor ) ],
         brick:Heat_Sensor ;
     brick:hasAssociatedTag tag:Heat,
+        tag:Point,
         tag:Sensor,
         tag:Trace .
 
 brick:Turn_Off_Status a owl:Class ;
     rdfs:label "Turn Off Status" ;
-    rdfs:subClassOf brick:Off_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Turn _:has_Off _:has_Status ) ],
+        brick:Off_Status ;
+    brick:hasAssociatedTag tag:Off,
+        tag:Point,
+        tag:Status,
+        tag:Turn .
 
 brick:Turn_On_Status a owl:Class ;
     rdfs:label "Turn On Status" ;
-    rdfs:subClassOf brick:On_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Turn _:has_On _:has_Status ) ],
+        brick:On_Status ;
+    brick:hasAssociatedTag tag:On,
+        tag:Point,
+        tag:Status,
+        tag:Turn .
 
 brick:Underfloor_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Underfloor Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Underfloor ;
                         owl:onProperty brick:hasTag ] _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Underfloor .
 
 brick:Unit_Failure_Alarm a owl:Class ;
     rdfs:label "Unit Failure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unit _:has_Failure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unit _:has_Failure _:has_Alarm ) ],
         brick:Failure_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Failure,
+        tag:Point,
         tag:Unit .
 
 brick:Unoccupied_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Cooling _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cooling _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Unoccupied_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Unoccupied_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Heating _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Heating _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Heating_Temperature_Setpoint,
         brick:Unoccupied_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf brick:Cooling_Discharge_Air_Flow_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Cooling_Discharge_Air_Flow_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cooling,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
 
 brick:Unoccupied_Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Unoccupied Hot Water Shutdown Command" ;
-    rdfs:subClassOf brick:Hot_Water_Shutdown_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
+        brick:Hot_Water_Shutdown_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Hot,
+        tag:Point,
+        tag:Shutdown,
+        tag:Unoccupied,
+        tag:Water .
 
 brick:Unoccupied_Mode_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Mode _:has_Setpoint ) ],
         brick:Mode_Setpoint ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Setpoint,
         tag:Unoccupied .
 
 brick:VFD_Enable_Command a owl:Class ;
     rdfs:label "VFD Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command [ a owl:Restriction ;
-                        owl:hasValue tag:VFD ;
-                        owl:onProperty brick:hasTag ] ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_VFD ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:VFD .
 
 brick:Valve_Command a owl:Class ;
     rdfs:label "Valve Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Valve _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Valve .
 
 brick:Variable_Air_Volume_Box_With_Reheat a owl:Class ;
     rdfs:label "Variable Air Volume Box With Reheat" ;
-    rdfs:subClassOf brick:Variable_Air_Volume_Box ;
-    owl:equivalentClass brick:RVAV .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box _:has_Reheat ) ],
+        brick:Variable_Air_Volume_Box ;
+    owl:equivalentClass brick:RVAV ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Reheat,
+        tag:Variable,
+        tag:Volume .
 
 brick:Variable_Frequency_Drive a owl:Class ;
     rdfs:label "Variable Frequency Drive" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Frequency _:has_Drive ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:VFD ;
-    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure." .
+    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure." ;
+    brick:hasAssociatedTag tag:Drive,
+        tag:Equipment,
+        tag:Frequency,
+        tag:Variable .
 
 brick:Velocity_Pressure_Setpoint a owl:Class ;
     rdfs:label "Velocity Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Velocity _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Velocity _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint,
         tag:Velocity .
 
 brick:Vent_Operating_Mode_Status a owl:Class ;
     rdfs:label "Vent Operating Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Vent ;
                         owl:onProperty brick:hasTag ] _:has_Operating _:has_Mode _:has_Status ) ],
         brick:Operating_Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Operating,
+        tag:Point,
         tag:Status,
         tag:Vent .
 
 brick:Ventilation_Air_Flow_Ratio_Limit a owl:Class ;
     rdfs:label "Ventilation Air Flow Ratio Limit" ;
-    rdfs:subClassOf brick:Limit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ventilation _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Ratio ;
+                        owl:onProperty brick:hasTag ] _:has_Limit ) ],
+        brick:Limit ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Point,
+        tag:Ratio,
+        tag:Ventilation .
 
 brick:Warm_Cool_Adjust_Sensor a owl:Class ;
     rdfs:label "Warm Cool Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust [ a owl:Restriction ;
                         owl:hasValue tag:Warm ;
                         owl:onProperty brick:hasTag ] _:has_Cool ) ],
         brick:Adjust_Sensor ;
     brick:hasAssociatedTag tag:Adjust,
         tag:Cool,
+        tag:Point,
         tag:Sensor,
         tag:Warm .
 
 brick:Water_Loss_Alarm a owl:Class ;
     rdfs:label "Water Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Loss _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Loss _:has_Water _:has_Alarm ) ],
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Loss,
+        tag:Point,
         tag:Water .
 
 brick:Weather a owl:Class ;
@@ -4334,23 +5232,25 @@ brick:Weather a owl:Class ;
 
 brick:Wind_Direction_Sensor a owl:Class ;
     rdfs:label "Wind Direction Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Direction _:has_Wind ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction _:has_Wind ) ],
         brick:Direction_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Wind_Direction ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Sensor,
         tag:Wind .
 
 brick:Wind_Speed_Sensor a owl:Class ;
     rdfs:label "Wind Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed _:has_Wind ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Wind ) ],
         brick:Speed_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Wind_Speed ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Speed,
         tag:Wind .
 
@@ -4365,18 +5265,19 @@ brick:Wing a owl:Class ;
 
 brick:Yearly_Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Yearly Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
                         owl:hasValue tag:Yearly ;
                         owl:onProperty brick:hasTag ] _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Steam_Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Usage,
         tag:Yearly .
 
 brick:Zone_Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Zone Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air _:has_Zone ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Zone ) ],
         brick:Air_Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -4385,25 +5286,41 @@ brick:Zone_Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor,
         tag:Zone .
 
 brick:Zone_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Zone Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Zone .
 
 brick:Zone_Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Standby Load Shed Command" ;
-    rdfs:subClassOf brick:Standby_Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Standby_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Standby,
+        tag:Zone .
 
 brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Zone Unoccupied Load Shed Command" ;
-    rdfs:subClassOf brick:Unoccupied_Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Unoccupied_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Unoccupied,
+        tag:Zone .
 
 brick:feedsAir a owl:ObjectProperty ;
     rdfs:subPropertyOf brick:feeds ;
@@ -4430,69 +5347,66 @@ brick:regulates a owl:AsymmetricProperty,
     skos:definition "The subject contributes to or performs the regulation of the substance given by the object" .
 
 brick:Acceleration_Time a owl:Class,
-        brick:Acceleration_Time,
-        brick:Time ;
-    rdfs:label "Acceleration Time" .
-
-brick:Active_Power a owl:Class,
-        brick:Active_Power,
-        brick:Electric_Power ;
-    rdfs:label "Active Power" ;
-    owl:equivalentClass brick:Real_Power .
+        brick:Acceleration_Time ;
+    rdfs:label "Acceleration Time" ;
+    rdfs:subClassOf brick:Time .
 
 brick:Air_Flow_Deadband_Setpoint a owl:Class ;
     rdfs:label "Air Flow Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint,
         brick:Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Air Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Static_Pressure_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
 
 brick:Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Limit,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Alternating_Current_Frequency a owl:Class,
-        brick:Alternating_Current_Frequency,
-        brick:Electric_Current,
-        brick:Frequency ;
-    rdfs:label "Alternating Current Frequency" .
+        brick:Alternating_Current_Frequency ;
+    rdfs:label "Alternating Current Frequency" ;
+    rdfs:subClassOf brick:Electric_Current,
+        brick:Frequency .
 
 brick:Apparent_Power a owl:Class,
-        brick:Apparent_Power,
-        brick:Electric_Power ;
-    rdfs:label "Apparent Power" .
+        brick:Apparent_Power ;
+    rdfs:label "Apparent Power" ;
+    rdfs:subClassOf brick:Electric_Power .
 
 brick:Atmospheric_Pressure a owl:Class,
-        brick:Atmospheric_Pressure,
-        brick:Pressure ;
-    rdfs:label "Atmospheric Pressure" .
+        brick:Atmospheric_Pressure ;
+    rdfs:label "Atmospheric Pressure" ;
+    rdfs:subClassOf brick:Pressure .
 
 brick:Blowdown_Water a owl:Class,
-        brick:Blowdown_Water,
-        brick:Water ;
+        brick:Blowdown_Water ;
     rdfs:label "Blowdown Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
                         owl:hasValue tag:Blowdown ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Water ;
     skos:definition "Water expelled from a system to remove mineral build up" ;
     brick:hasAssociatedTag tag:Blowdown,
         tag:Fluid,
@@ -4501,85 +5415,113 @@ brick:Blowdown_Water a owl:Class,
 
 brick:CO2_Alarm a owl:Class ;
     rdfs:label "CO2 Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:CO2 .
+        tag:CO2,
+        tag:Point .
 
 brick:CO2_Level a owl:Class,
-        brick:Air_Quality,
-        brick:CO2_Level,
-        brick:Level ;
-    rdfs:label "CO2 Level" .
+        brick:CO2_Level ;
+    rdfs:label "CO2 Level" ;
+    rdfs:subClassOf brick:Air_Quality,
+        brick:Level .
 
 brick:CO2_Setpoint a owl:Class ;
     rdfs:label "CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:CO2,
+        tag:Point,
         tag:Setpoint .
 
 brick:CRAC a owl:Class ;
     rdfs:label "CRAC" ;
-    rdfs:subClassOf brick:HVAC ;
-    owl:equivalentClass brick:Computer_Room_Air_Conditioning .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:CRAC ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    owl:equivalentClass brick:Computer_Room_Air_Conditioning ;
+    brick:hasAssociatedTag tag:CRAC,
+        tag:Equipment .
 
 brick:CWS a owl:Class ;
     rdfs:label "CWS" ;
-    rdfs:subClassOf brick:Water_System ;
-    owl:equivalentClass brick:Chilled_Water_System .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:CWS ;
+            owl:onProperty brick:hasTag ],
+        brick:Water_System ;
+    owl:equivalentClass brick:Chilled_Water_System ;
+    brick:hasAssociatedTag tag:CWS .
 
 brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Chilled_Water_Differential_Pressure_Setpoint,
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Chilled_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status,
         tag:Water .
 
 brick:Cloudage a owl:Class,
-        brick:Cloudage,
-        brick:Quantity ;
-    rdfs:label "Cloudage" .
+        brick:Cloudage ;
+    rdfs:label "Cloudage" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Coldest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf brick:Zone_Air_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Coldest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Coldest,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Zone .
 
 brick:Complex_Power a owl:Class,
-        brick:Complex_Power,
-        brick:Electric_Power ;
-    rdfs:label "Complex Power" .
+        brick:Complex_Power ;
+    rdfs:label "Complex Power" ;
+    rdfs:subClassOf brick:Electric_Power .
 
 brick:Computer_Room_Air_Conditioning a owl:Class ;
     rdfs:label "Computer Room Air Conditioning" ;
-    rdfs:subClassOf brick:HVAC ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Computer ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Air _:has_Conditioning ) ],
+        brick:HVAC ;
     owl:equivalentClass brick:CRAC ;
-    skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " .
+    skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center. " ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Computer,
+        tag:Conditioning,
+        tag:Equipment,
+        tag:Room .
 
 brick:Condenser_Water a owl:Class,
-        brick:Condenser_Water,
-        brick:Water ;
+        brick:Condenser_Water ;
     rdfs:label "Condenser Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
-                        owl:hasValue tag:Condenser ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Condenser ) ],
+        brick:Water ;
     skos:definition "Water used used to remove heat through condensation" ;
     brick:hasAssociatedTag tag:Condenser,
         tag:Fluid,
@@ -4588,120 +5530,138 @@ brick:Condenser_Water a owl:Class,
 
 brick:Conductivity_Sensor a owl:Class ;
     rdfs:label "Conductivity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Conductivity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Conductivity ;
                         owl:onProperty brick:measures ] ) ] ;
     skos:definition "senses or detects electrical conductance" ;
     brick:hasAssociatedTag tag:Conductivity,
+        tag:Point,
         tag:Sensor .
 
 brick:Cooling_Command a owl:Class ;
     rdfs:label "Cooling Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cool _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Cool .
+        tag:Cool,
+        tag:Point .
 
 brick:Cooling_Request_Setpoint a owl:Class ;
     rdfs:label "Cooling Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Request _:has_Setpoint ) ],
         brick:Request_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Current_Angle a owl:Class,
-        brick:Current_Angle,
-        brick:Electric_Current ;
-    rdfs:label "Current Angle" .
+        brick:Current_Angle ;
+    rdfs:label "Current Angle" ;
+    rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Imbalance a owl:Class,
-        brick:Current_Imbalance,
-        brick:Electric_Current ;
-    rdfs:label "Current Imbalance" .
+        brick:Current_Imbalance ;
+    rdfs:label "Current Imbalance" ;
+    rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Magnitude a owl:Class,
-        brick:Current_Magnitude,
-        brick:Electric_Current ;
-    rdfs:label "Current Magnitude" .
+        brick:Current_Magnitude ;
+    rdfs:label "Current Magnitude" ;
+    rdfs:subClassOf brick:Electric_Current .
 
 brick:Current_Total_Harmonic_Distortion a owl:Class,
-        brick:Current_Total_Harmonic_Distortion,
-        brick:Electric_Current ;
-    rdfs:label "Current Total Harmonic Distortion" .
+        brick:Current_Total_Harmonic_Distortion ;
+    rdfs:label "Current Total Harmonic Distortion" ;
+    rdfs:subClassOf brick:Electric_Current .
 
 brick:Cycle_Alarm a owl:Class ;
     rdfs:label "Cycle Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cycle _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cycle _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Cycle .
+        tag:Cycle,
+        tag:Point .
 
 brick:Damper_Command a owl:Class ;
     rdfs:label "Damper Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Damper _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Damper .
+        tag:Damper,
+        tag:Point .
 
 brick:Daytime a owl:Class,
-        brick:Daytime,
-        brick:Quantity ;
-    rdfs:label "Daytime" .
+        brick:Daytime ;
+    rdfs:label "Daytime" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Deceleration_Time a owl:Class,
-        brick:Deceleration_Time,
-        brick:Time ;
-    rdfs:label "Deceleration Time" .
+        brick:Deceleration_Time ;
+    rdfs:label "Deceleration Time" ;
+    rdfs:subClassOf brick:Time .
 
 brick:Delay_Parameter a owl:Class ;
     rdfs:label "Delay Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Delay _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Delay _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Delay,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
+
+brick:Demand_Sensor a owl:Class ;
+    rdfs:label "Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand ) ],
+        brick:Sensor ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Point,
+        tag:Sensor .
 
 brick:Differential_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Differential Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Step .
 
 brick:Direction_Sensor a owl:Class ;
     rdfs:label "Direction Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Direction ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Direction ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Sensor .
 
 brick:Direction_Status a owl:Class ;
     rdfs:label "Direction Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Direction _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Direction,
+        tag:Point,
         tag:Status .
 
 brick:Discharge_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Discharge Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Discharge ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -4711,54 +5671,59 @@ brick:Discharge_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Discharge_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Discharge Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
         tag:Discharge,
+        tag:Point,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Cooling_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Cooling Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Cooling _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Cooling _:has_Setpoint ) ],
         brick:Cooling_Temperature_Setpoint,
         brick:Discharge_Air_Temperature_Setpoint ;
-    owl:equivalentClass brick:Maximum_Discharge_Air_Temperature_Setpoint ;
+    owl:equivalentClass brick:Max_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Heating_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Heating Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Heating _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heating _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint,
         brick:Heating_Temperature_Setpoint ;
-    owl:equivalentClass brick:Minimum_Discharge_Air_Temperature_Setpoint ;
+    owl:equivalentClass brick:Min_Discharge_Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Discharge Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Discharge ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -4767,23 +5732,25 @@ brick:Discharge_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
         tag:Discharge,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band,
         brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter,
         brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter ;
@@ -4792,13 +5759,14 @@ brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Cl
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Water .
 
 brick:Discharge_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Discharge Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Discharge ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge ) ],
         brick:Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -4807,6 +5775,7 @@ brick:Discharge_Water_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -4821,19 +5790,20 @@ brick:Domestic_Hot_Water_System a owl:Class ;
 
 brick:Domestic_Hot_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Domestic Hot Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Hot,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Domestic_Water a owl:Class,
-        brick:Domestic_Water,
-        brick:Water ;
+        brick:Domestic_Water ;
     rdfs:label "Domestic Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Domestic ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Domestic ) ],
+        brick:Water ;
     skos:definition "Tap water for drinking, washing, cooking, and flushing of toliets" ;
     brick:hasAssociatedTag tag:Domestic,
         tag:Fluid,
@@ -4841,23 +5811,24 @@ brick:Domestic_Water a owl:Class,
         tag:Water .
 
 brick:Dry_Bulb_Temperature a owl:Class,
-        brick:Dry_Bulb_Temperature,
-        brick:Temperature ;
-    rdfs:label "Dry Bulb Temperature" .
+        brick:Dry_Bulb_Temperature ;
+    rdfs:label "Dry Bulb Temperature" ;
+    rdfs:subClassOf brick:Temperature .
 
 brick:Electric_Energy a owl:Class,
-        brick:Electric_Energy,
-        brick:Energy ;
-    rdfs:label "Electric Energy" .
+        brick:Electric_Energy ;
+    rdfs:label "Electric Energy" ;
+    rdfs:subClassOf brick:Energy .
 
 brick:Energy_Sensor a owl:Class ;
     rdfs:label "Energy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Energy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Energy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Energy,
+        tag:Point,
         tag:Sensor .
 
 brick:Energy_Storage a owl:Class ;
@@ -4870,17 +5841,18 @@ brick:Energy_Storage a owl:Class ;
 
 brick:Enthalpy_Sensor a owl:Class ;
     rdfs:label "Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Enthalpy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Enthalpy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Flow_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Flow Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
@@ -4888,11 +5860,12 @@ brick:Exhaust_Air_Flow_Integral_Time_Parameter a owl:Class ;
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Exhaust_Air_Flow_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Exhaust Air Flow Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
@@ -4900,11 +5873,12 @@ brick:Exhaust_Air_Flow_Proportional_Band_Parameter a owl:Class ;
         tag:Flow,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Exhaust ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -4914,118 +5888,140 @@ brick:Exhaust_Air_Flow_Sensor a owl:Class ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Exhaust_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Exhaust_Air_Stack_Flow_Setpoint a owl:Class ;
     rdfs:label "Exhaust Air Stack Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Setpoint ) ],
         brick:Exhaust_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Stack .
 
 brick:FCP a owl:Class ;
     rdfs:label "FCP" ;
-    rdfs:subClassOf brick:Fire_Safety_System .
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:FCP ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Fire_Safety_System ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:FCP .
 
 brick:FCU a owl:Class ;
     rdfs:label "FCU" ;
-    rdfs:subClassOf brick:Terminal_Unit .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:FCU ;
+            owl:onProperty brick:hasTag ],
+        brick:Terminal_Unit ;
+    brick:hasAssociatedTag tag:FCU .
 
 brick:Failure_Alarm a owl:Class ;
     rdfs:label "Failure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Failure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Failure _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Failure .
+        tag:Failure,
+        tag:Point .
 
 brick:Fan_Status a owl:Class ;
     rdfs:label "Fan Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fan _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Fan,
+        tag:Point,
         tag:Status .
 
 brick:Filter a owl:Class ;
     rdfs:label "Filter" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Device to remove gases from a mixture of gases" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Filter ) ],
+        brick:HVAC ;
+    skos:definition "Device to remove gases from a mixture of gases" ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Filter .
 
 brick:Filter_Status a owl:Class ;
     rdfs:label "Filter Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Filter _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Filter,
+        tag:Point,
         tag:Status .
 
 brick:Flow_Loss a owl:Class,
-        brick:Flow,
         brick:Flow_Loss ;
-    rdfs:label "Flow Loss" .
+    rdfs:label "Flow Loss" ;
+    rdfs:subClassOf brick:Flow .
 
 brick:Flow_Setpoint a owl:Class ;
     rdfs:label "Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Flow _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Frequency_Command a owl:Class ;
     rdfs:label "Frequency Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fequency _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fequency _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Fequency .
+        tag:Fequency,
+        tag:Point .
 
 brick:Frequency_Sensor a owl:Class ;
     rdfs:label "Frequency Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Frequency ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frequency ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Frequency ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Frequency,
+        tag:Point,
         tag:Sensor .
 
 brick:Fresh_Air_Setpoint_Limit a owl:Class ;
     rdfs:label "Fresh Air Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Fresh,
         tag:Limit,
+        tag:Point,
         tag:Setpoint .
 
 brick:Fuel_Oil a owl:Class,
-        brick:Fuel_Oil,
-        brick:Oil ;
+        brick:Fuel_Oil ;
     rdfs:label "Fuel Oil" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Liquid _:has_Oil [ a owl:Restriction ;
                         owl:hasValue tag:Fuel ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Oil ;
     skos:definition "Petroleum based oil burned for energy" ;
     brick:hasAssociatedTag tag:Fuel,
         tag:Liquid,
         tag:Oil .
 
 brick:Gasoline a owl:Class,
-        brick:Gasoline,
-        brick:Liquid ;
+        brick:Gasoline ;
     rdfs:label "Gasoline" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid [ a owl:Restriction ;
                         owl:hasValue tag:Gasoline ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Liquid ;
     skos:definition "Petroleum derived liquid used as a fuel source" ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Gasoline,
@@ -5033,57 +6029,76 @@ brick:Gasoline a owl:Class,
 
 brick:HWS a owl:Class ;
     rdfs:label "HWS" ;
-    rdfs:subClassOf brick:Water_System ;
-    owl:equivalentClass brick:Hot_Water_System .
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:hasValue tag:HWS ;
+            owl:onProperty brick:hasTag ],
+        brick:Water_System ;
+    owl:equivalentClass brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:HWS .
 
 brick:HX a owl:Class ;
     rdfs:label "HX" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:HX ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:HX .
 
 brick:Heat_Sensor a owl:Class ;
     rdfs:label "Heat Sensor" ;
-    rdfs:subClassOf brick:Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Heat ) ],
+        brick:Sensor ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Sensor .
 
 brick:Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Heating Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:Heating,
+        tag:Point,
         tag:Setpoint .
 
 brick:Heating_Request_Setpoint a owl:Class ;
     rdfs:label "Heating Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Request _:has_Setpoint ) ],
         brick:Request_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Request,
         tag:Setpoint .
 
 brick:Heating_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Heating Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Heating_Ventilation_Air_Conditioning_System a owl:Class ;
     rdfs:label "Heating Ventilation Air Conditioning System" ;
-    rdfs:subClassOf brick:Equipment ;
-    owl:equivalentClass brick:HVAC .
+    rdfs:subClassOf _:has_HVAC,
+        brick:Equipment ;
+    owl:equivalentClass brick:HVAC ;
+    brick:hasAssociatedTag tag:HVAC .
 
 brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Differential_Pressure_Load_Shed_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status,
@@ -5091,7 +6106,7 @@ brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
         brick:Differential_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
@@ -5100,35 +6115,39 @@ brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Water .
 
 brick:Hot_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Hot Water Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Hot,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Hot_Water_Shutdown_Command a owl:Class ;
     rdfs:label "Hot Water Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Shutdown _:has_Command ) ],
         brick:Shutdown_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Hot,
+        tag:Point,
         tag:Shutdown,
         tag:Water .
 
 brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status ;
     brick:hasAssociatedTag tag:Hot,
         tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status,
         tag:Supply,
@@ -5137,62 +6156,67 @@ brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
 
 brick:Hot_Water_System_Enable_Command a owl:Class ;
     rdfs:label "Hot Water System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_Hot _:has_Water _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Hot _:has_Water _:has_System ) ],
         brick:System_Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
         tag:Hot,
+        tag:Point,
         tag:System,
         tag:Water .
 
 brick:Humidity_Sensor a owl:Class ;
     rdfs:label "Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Ice a owl:Class,
-        brick:Ice,
-        brick:Solid ;
+        brick:Ice ;
     rdfs:label "Ice" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Ice ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Ice ) ],
+        brick:Solid ;
     skos:definition "Water in its solid form" ;
     brick:hasAssociatedTag tag:Ice,
         tag:Solid .
 
 brick:Illuminance_Sensor a owl:Class ;
     rdfs:label "Illuminance Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Illuminance ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Illuminance ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Illuminance,
+        tag:Point,
         tag:Sensor .
 
 brick:Integral_Gain_Parameter a owl:Class ;
     rdfs:label "Integral Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Integral ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:Integral,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Leak_Alarm a owl:Class ;
     rdfs:label "Leak Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Leak _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leak _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Leak .
+        tag:Leak,
+        tag:Point .
 
 brick:Leaving_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Leaving Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Leaving ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Leaving ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -5200,15 +6224,16 @@ brick:Leaving_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Leaving_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Liquid_CO2 a owl:Class,
-        brick:Liquid,
         brick:Liquid_CO2 ;
     rdfs:label "Liquid CO2" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_CO2 ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_CO2 ) ],
+        brick:Liquid ;
     skos:definition "Carbon Dioxide in the liquid phase" ;
     brick:hasAssociatedTag tag:CO2,
         tag:Fluid,
@@ -5216,226 +6241,274 @@ brick:Liquid_CO2 a owl:Class,
 
 brick:Load_Parameter a owl:Class ;
     rdfs:label "Load Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Load,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Load_Setpoint a owl:Class ;
     rdfs:label "Load Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Setpoint .
 
 brick:Load_Shed_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Load Shed Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint,
         brick:Load_Shed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Shed .
 
 brick:Low_Temperature_Alarm a owl:Class ;
     rdfs:label "Low Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Low _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Low,
+        tag:Point,
         tag:Temperature .
 
 brick:Luminous_Flux a owl:Class,
-        brick:Luminance,
         brick:Luminous_Flux ;
-    rdfs:label "Luminous Flux" .
+    rdfs:label "Luminous Flux" ;
+    rdfs:subClassOf brick:Luminance .
 
 brick:Luminous_Intensity a owl:Class,
-        brick:Luminance,
         brick:Luminous_Intensity ;
-    rdfs:label "Luminous Intensity" .
+    rdfs:label "Luminous Intensity" ;
+    rdfs:subClassOf brick:Luminance .
 
 brick:Makeup_Water a owl:Class,
-        brick:Makeup_Water,
-        brick:Water ;
+        brick:Makeup_Water ;
     rdfs:label "Makeup Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
                         owl:hasValue tag:Makeup ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Water ;
     skos:definition "Water used used to makeup water loss through leaks, evaporation, or blowdown" ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Liquid,
         tag:Makeup,
         tag:Water .
 
+brick:Max_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Max Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Max _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Max,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
 brick:Max_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
-brick:Maximum_Discharge_Air_Temperature_Setpoint a owl:Class ;
-    rdfs:label "Maximum Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Setpoint .
-
 brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf brick:Differential_Pressure_Load_Shed_Status .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
+
+brick:Min_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Min Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Min _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Min,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Min_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
-brick:Minimum_Discharge_Air_Temperature_Setpoint a owl:Class ;
-    rdfs:label "Minimum Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf brick:Discharge_Air_Temperature_Setpoint .
-
 brick:Motion_Sensor a owl:Class ;
     rdfs:label "Motion Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor [ a owl:Restriction ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
                         owl:hasValue tag:Motion ;
                         owl:onProperty brick:hasTag ] ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Motion,
+        tag:Point,
         tag:Sensor .
 
 brick:Natural_Gas a owl:Class,
-        brick:Gas,
         brick:Natural_Gas ;
     rdfs:label "Natural Gas" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas [ a owl:Restriction ;
                         owl:hasValue tag:Natural ;
-                        owl:onProperty brick:hasTag ] ) ] ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Gas ;
     skos:definition "Fossil fuel energy source consisting largely of methane and other hydrocarbons" ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Gas,
         tag:Natural .
 
 brick:Occupancy_Count a owl:Class,
-        brick:Occupancy,
         brick:Occupancy_Count ;
-    rdfs:label "Occupancy Count" .
+    rdfs:label "Occupancy Count" ;
+    rdfs:subClassOf brick:Occupancy .
 
 brick:Occupancy_Percentage a owl:Class,
-        brick:Occupancy,
         brick:Occupancy_Percentage ;
-    rdfs:label "Occupancy Percentage" .
+    rdfs:label "Occupancy Percentage" ;
+    rdfs:subClassOf brick:Occupancy .
 
 brick:Occupancy_Sensor a owl:Class ;
     rdfs:label "Occupancy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Occupancy ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Occupancy ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Occupancy ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Sensor .
 
 brick:Occupancy_Status a owl:Class ;
     rdfs:label "Occupancy Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupancy _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
         tag:Status .
 
 brick:Off_Command a owl:Class ;
     rdfs:label "Off Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:Point .
 
 brick:On_Command a owl:Class ;
     rdfs:label "On Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:On,
+        tag:Point .
 
 brick:Operating_Mode_Status a owl:Class ;
     rdfs:label "Operating Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Operating _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Operating _:has_Mode _:has_Status ) ],
         brick:Mode_Status ;
     brick:hasAssociatedTag tag:Mode,
         tag:Operating,
+        tag:Point,
         tag:Status .
 
 brick:Operative_Temperature a owl:Class,
-        brick:Operative_Temperature,
-        brick:Temperature ;
-    rdfs:label "Operative Temperature" .
+        brick:Operative_Temperature ;
+    rdfs:label "Operative Temperature" ;
+    rdfs:subClassOf brick:Temperature .
 
 brick:Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Temperature Enable Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Enable,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Override_Command a owl:Class ;
     rdfs:label "Override Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Override _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Override _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Override .
+        tag:Override,
+        tag:Point .
 
 brick:PM10_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:PM10_Level ;
-    rdfs:label "PM10 Level" .
+    rdfs:label "PM10 Level" ;
+    rdfs:subClassOf brick:Air_Quality,
+        brick:Level .
 
 brick:PM25_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:PM25_Level ;
-    rdfs:label "PM25 Level" .
+    rdfs:label "PM25 Level" ;
+    rdfs:subClassOf brick:Air_Quality,
+        brick:Level .
 
 brick:PV_Current_Output_Sensor a owl:Class ;
     rdfs:label "PV Current Output Sensor" ;
-    rdfs:subClassOf brick:Current_Output_Sensor .
-
-brick:Peak_Power a owl:Class,
-        brick:Peak_Power,
-        brick:Power ;
-    rdfs:label "Peak Power" ;
-    skos:definition "Tracks the highest (peak) observed power in some interval" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:PV ;
+                        owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
+        brick:Current_Output_Sensor ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Output,
+        tag:PV,
+        tag:Point,
+        tag:Sensor .
 
 brick:Position_Command a owl:Class ;
     rdfs:label "Position Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Position .
 
 brick:Power_Alarm a owl:Class ;
     rdfs:label "Power Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Power .
 
 brick:Power_Factor a owl:Class,
-        brick:Power_Factor,
-        brick:Quantity ;
-    rdfs:label "Power Factor" .
+        brick:Power_Factor ;
+    rdfs:label "Power Factor" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Power_Loss_Alarm a owl:Class ;
     rdfs:label "Power Loss Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Power _:has_Loss _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Alarm ) ],
         brick:Power_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Loss,
+        tag:Point,
         tag:Power .
 
 brick:Power_Meter a owl:Class ;
@@ -5455,56 +6528,67 @@ brick:Power_System a owl:Class ;
         tag:Power .
 
 brick:Precipitation a owl:Class,
-        brick:Precipitation,
-        brick:Quantity ;
-    rdfs:label "Precipitation" .
+        brick:Precipitation ;
+    rdfs:label "Precipitation" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Proportional_Gain_Parameter a owl:Class ;
     rdfs:label "Proportional Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain _:has_Proportional ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional ) ],
         brick:Gain_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Pump a owl:Class ;
     rdfs:label "Pump" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump ) ],
+        brick:HVAC ;
+    skos:definition "Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump .
 
 brick:RTU a owl:Class ;
     rdfs:label "RTU" ;
-    rdfs:subClassOf brick:AHU ;
-    owl:equivalentClass brick:Rooftop_Unit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RTU ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:AHU ;
+    owl:equivalentClass brick:Rooftop_Unit ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RTU .
 
 brick:RVAV a owl:Class ;
     rdfs:label "RVAV" ;
-    rdfs:subClassOf brick:Variable_Air_Volume_Box .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RVAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Variable_Air_Volume_Box ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RVAV .
 
 brick:Radiant_Temperature a owl:Class,
-        brick:Radiant_Temperature,
-        brick:Temperature ;
-    rdfs:label "Radiant Temperature" .
+        brick:Radiant_Temperature ;
+    rdfs:label "Radiant Temperature" ;
+    rdfs:subClassOf brick:Temperature .
 
 brick:Rain_Sensor a owl:Class ;
     rdfs:label "Rain Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Rain ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain ) ],
         brick:Sensor ;
-    brick:hasAssociatedTag tag:Rain,
+    brick:hasAssociatedTag tag:Point,
+        tag:Rain,
         tag:Sensor .
-
-brick:Reactive_Power a owl:Class,
-        brick:Electric_Power,
-        brick:Reactive_Power ;
-    rdfs:label "Reactive Power" .
 
 brick:Return_Air_CO2_Setpoint a owl:Class ;
     rdfs:label "Return Air CO2 Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
         brick:CO2_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:CO2,
+        tag:Point,
         tag:Return,
         tag:Setpoint .
 
@@ -5521,63 +6605,79 @@ brick:Rooftop_Unit a owl:Class ;
 
 brick:Shutdown_Command a owl:Class ;
     rdfs:label "Shutdown Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shutdown _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shutdown _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
+        tag:Point,
         tag:Shutdown .
 
 brick:Smoke_Alarm a owl:Class ;
     rdfs:label "Smoke Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Smoke _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Smoke .
 
 brick:Smoke_Detected_Alarm a owl:Class ;
     rdfs:label "Smoke Detected Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Smoke _:has_Detected _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Detected _:has_Alarm ) ],
         brick:Smoke_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:Detected,
+        tag:Point,
         tag:Smoke .
 
 brick:Solar_Irradiance a owl:Class,
-        brick:Irradiance,
         brick:Solar_Irradiance ;
-    rdfs:label "Solar Irradiance" .
+    rdfs:label "Solar Irradiance" ;
+    rdfs:subClassOf brick:Irradiance .
+
+brick:Speed_Reset_Command a owl:Class ;
+    rdfs:label "Speed Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Reset,
+        tag:Speed .
 
 brick:Standby_Load_Shed_Command a owl:Class ;
     rdfs:label "Standby Load Shed Command" ;
-    rdfs:subClassOf brick:Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Standby .
 
 brick:Standby_Unit_On_Off_Status a owl:Class ;
     rdfs:label "Standby Unit On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Standby _:has_Unit _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Unit _:has_On _:has_Off _:has_Status ) ],
         brick:On_Off_Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Standby,
         tag:Status,
         tag:Unit .
 
-brick:Start_Stop_Command a owl:Class ;
-    rdfs:label "Start Stop Command" ;
-    rdfs:subClassOf brick:On_Off_Command .
-
 brick:Static_Pressure_Step_Parameter a owl:Class ;
     rdfs:label "Static Pressure Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Step .
 
 brick:Steam a owl:Class,
-        brick:Gas,
         brick:Steam ;
     rdfs:label "Steam" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Steam ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Steam ) ],
+        brick:Gas ;
     skos:definition "water in the vapor phase." ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Gas,
@@ -5585,7 +6685,7 @@ brick:Steam a owl:Class,
 
 brick:Supply_Air_Flow_Sensor a owl:Class ;
     rdfs:label "Supply Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Supply ) ],
         brick:Air_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -5594,14 +6694,16 @@ brick:Supply_Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply .
 
 brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Supply Air Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static,
@@ -5609,7 +6711,7 @@ brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
 
 brick:Supply_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Supply Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Supply ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -5617,6 +6719,7 @@ brick:Supply_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature .
@@ -5631,10 +6734,11 @@ brick:Supply_Fan a owl:Class ;
 
 brick:Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Differential_Pressure_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Supply,
@@ -5642,12 +6746,13 @@ brick:Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
 
 brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Water Differential Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Differential_Pressure_Proportional_Band ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Supply,
@@ -5655,7 +6760,7 @@ brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class
 
 brick:Supply_Water_Flow_Sensor a owl:Class ;
     rdfs:label "Supply Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply ) ],
         brick:Water_Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -5663,91 +6768,115 @@ brick:Supply_Water_Flow_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Water .
 
 brick:Switch a owl:Class ;
     rdfs:label "Switch" ;
-    rdfs:subClassOf brick:Interface .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch ) ],
+        brick:Interface ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Switch .
 
 brick:TVOC_Level a owl:Class,
-        brick:Air_Quality,
-        brick:Level,
         brick:TVOC_Level ;
-    rdfs:label "TVOC Level" .
-
-brick:Temperature_High_Reset_Setpoint a owl:Class ;
-    rdfs:label "Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
+    rdfs:label "TVOC Level" ;
+    rdfs:subClassOf brick:Air_Quality,
+        brick:Level .
 
 brick:Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Step_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
 brick:Thermal_Energy a owl:Class,
-        brick:Energy,
         brick:Thermal_Energy ;
-    rdfs:label "Thermal Energy" .
+    rdfs:label "Thermal Energy" ;
+    rdfs:subClassOf brick:Energy .
 
 brick:Thermal_Power a owl:Class,
-        brick:Power,
         brick:Thermal_Power ;
-    rdfs:label "Thermal Power" .
+    rdfs:label "Thermal Power" ;
+    rdfs:subClassOf brick:Power .
 
 brick:Thermal_Power_Sensor a owl:Class ;
     rdfs:label "Thermal Power Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Power _:has_Thermal ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Thermal ) ],
         brick:Power_Sensor ;
-    brick:hasAssociatedTag tag:Power,
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
         tag:Sensor,
         tag:Thermal .
 
 brick:Torque_Sensor a owl:Class ;
     rdfs:label "Torque Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Torque ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Torque ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Torque ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Torque .
 
 brick:Unoccupied_Load_Shed_Command a owl:Class ;
     rdfs:label "Unoccupied Load Shed Command" ;
-    rdfs:subClassOf brick:Load_Shed_Command .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Unoccupied .
 
 brick:VAV a owl:Class ;
     rdfs:label "VAV" ;
-    rdfs:subClassOf brick:Terminal_Unit .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:VAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Terminal_Unit ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VAV .
 
 brick:Voltage_Angle a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Angle ;
-    rdfs:label "Voltage Angle" .
+    rdfs:label "Voltage Angle" ;
+    rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Voltage_Imbalance a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Imbalance ;
-    rdfs:label "Voltage Imbalance" .
+    rdfs:label "Voltage Imbalance" ;
+    rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Voltage_Magnitude a owl:Class,
-        brick:Electric_Voltage,
         brick:Voltage_Magnitude ;
-    rdfs:label "Voltage Magnitude" .
+    rdfs:label "Voltage Magnitude" ;
+    rdfs:subClassOf brick:Electric_Voltage .
 
 brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Warmest Zone Air Temperature Sensor" ;
-    rdfs:subClassOf brick:Zone_Air_Temperature_Sensor .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Warmest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Warmest,
+        tag:Zone .
 
 brick:Water_Level_Sensor a owl:Class ;
     rdfs:label "Water Level Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Water _:has_Level ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Water ;
@@ -5755,6 +6884,7 @@ brick:Water_Level_Sensor a owl:Class ;
                         owl:hasValue brick:Level ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Level,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
@@ -5769,21 +6899,22 @@ brick:Water_Meter a owl:Class ;
 
 brick:Water_Usage_Sensor a owl:Class ;
     rdfs:label "Water Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Water ) ],
         brick:Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Usage,
         tag:Water .
 
 brick:Weather_Condition a owl:Class,
-        brick:Quantity,
         brick:Weather_Condition ;
-    rdfs:label "Weather Condition" .
+    rdfs:label "Weather Condition" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Wet_Bulb_Temperature a owl:Class,
-        brick:Temperature,
         brick:Wet_Bulb_Temperature ;
-    rdfs:label "Wet Bulb Temperature" .
+    rdfs:label "Wet Bulb Temperature" ;
+    rdfs:subClassOf brick:Temperature .
 
 brick:controls a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -5871,25 +7002,23 @@ brick:isTagOf a owl:AsymmetricProperty,
         owl:ObjectProperty ;
     rdfs:domain brick:Tag .
 
-tag:Point a brick:Tag .
+brick:Active_Power a owl:Class,
+        brick:Active_Power ;
+    rdfs:label "Active Power" ;
+    rdfs:subClassOf brick:Electric_Power ;
+    owl:equivalentClass brick:Real_Power .
 
 brick:Adjust_Sensor a owl:Class ;
     rdfs:label "Adjust Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Adjust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Adjust,
+        tag:Point,
         tag:Sensor .
-
-brick:Air_Alarm a owl:Class ;
-    rdfs:label "Air Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Alarm ) ],
-        brick:Alarm ;
-    brick:hasAssociatedTag tag:Air,
-        tag:Alarm .
 
 brick:Air_Enthalpy_Sensor a owl:Class ;
     rdfs:label "Air Enthalpy Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Enthalpy _:has_Sensor ) ],
         brick:Enthalpy_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Enthalpy ;
@@ -5898,31 +7027,34 @@ brick:Air_Enthalpy_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Enthalpy,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Flow_Demand_Setpoint a owl:Class ;
     rdfs:label "Air Flow Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint,
         brick:Demand_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Demand,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Grains_Sensor a owl:Class ;
     rdfs:label "Air Grains Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Air _:has_Grains ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Air _:has_Grains ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Air ;
@@ -5931,37 +7063,40 @@ brick:Air_Grains_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Grains,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Temperature_Step_Parameter a owl:Class ;
     rdfs:label "Air Temperature Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
         brick:Temperature_Step_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Parameter,
+        tag:Point,
         tag:Step,
         tag:Temperature .
 
 brick:Angle a owl:Class,
-        brick:Angle,
-        brick:Quantity ;
-    rdfs:label "Angle" .
+        brick:Angle ;
+    rdfs:label "Angle" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Angle_Sensor a owl:Class ;
     rdfs:label "Angle Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Angle _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Angle _:has_Sensor ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Angle ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Angle,
+        tag:Point,
         tag:Sensor .
 
 brick:Building_Air a owl:Class,
-        brick:Air,
         brick:Building_Air ;
     rdfs:label "Building Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Building ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Building ) ],
+        brick:Air ;
     skos:definition "air contained within a building" ;
     brick:hasAssociatedTag tag:Air,
         tag:Building,
@@ -5969,10 +7104,10 @@ brick:Building_Air a owl:Class,
         tag:Gas .
 
 brick:Bypass_Air a owl:Class,
-        brick:Air,
         brick:Bypass_Air ;
     rdfs:label "Bypass Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Bypass ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Bypass ) ],
+        brick:Air ;
     skos:definition "air in a bypass duct, used to relieve static pressure" ;
     brick:hasAssociatedTag tag:Air,
         tag:Bypass,
@@ -5980,23 +7115,27 @@ brick:Bypass_Air a owl:Class,
         tag:Gas .
 
 brick:Capacity a owl:Class,
-        brick:Capacity,
-        brick:Quantity ;
-    rdfs:label "Capacity" .
+        brick:Capacity ;
+    rdfs:label "Capacity" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Chilled Water Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Water .
 
 brick:Chiller a owl:Class ;
     rdfs:label "Chiller" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Chiller,
+        tag:Equipment .
 
 brick:Coil a owl:Class ;
     rdfs:label "Coil" ;
@@ -6008,51 +7147,61 @@ brick:Coil a owl:Class ;
 
 brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Cooling Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Current_Output_Sensor a owl:Class ;
     rdfs:label "Current Output Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Current _:has_Output _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Output _:has_Sensor ) ],
         brick:Current_Sensor ;
     brick:hasAssociatedTag tag:Current,
         tag:Output,
+        tag:Point,
         tag:Sensor .
 
 brick:Dewpoint_Sensor a owl:Class ;
     rdfs:label "Dewpoint Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Dewpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Dewpoint ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
         tag:Sensor .
 
 brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint ;
-    skos:definition "Setpoints used in Reset strategies" .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Discharge_Air_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Discharge Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
@@ -6060,28 +7209,38 @@ brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
         tag:Discharge,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Temperature .
 
 brick:Discharge_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Differential_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Limit,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Discharge_Chilled_Water a owl:Class,
-        brick:Chilled_Water,
         brick:Discharge_Chilled_Water ;
     rdfs:label "Discharge Chilled Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Discharge ) ],
+        brick:Chilled_Water,
         brick:Discharge_Water ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Discharge,
@@ -6091,32 +7250,35 @@ brick:Discharge_Chilled_Water a owl:Class,
 
 brick:Effective_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Effective Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Effective _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Effective,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Emergency_Alarm a owl:Class ;
     rdfs:label "Emergency Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Emergency .
+        tag:Emergency,
+        tag:Point .
 
 brick:Enable_Status a owl:Class ;
     rdfs:label "Enable Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Enable,
+        tag:Point,
         tag:Status .
 
 brick:Entering_Water a owl:Class,
-        brick:Entering_Water,
-        brick:Water ;
+        brick:Entering_Water ;
     rdfs:label "Entering Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Entering ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Entering ) ],
+        brick:Water ;
     brick:hasAssociatedTag tag:Entering,
         tag:Fluid,
         tag:Liquid,
@@ -6124,7 +7286,7 @@ brick:Entering_Water a owl:Class,
 
 brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Exhaust Air Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Exhaust ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Exhaust ) ],
         brick:Static_Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Static_Pressure ;
@@ -6133,59 +7295,72 @@ brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
+        tag:Point,
         tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Fire_Safety_System a owl:Class ;
     rdfs:label "Fire Safety System" ;
-    rdfs:subClassOf brick:Equipment .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety _:has_System ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Safety,
+        tag:System .
 
 brick:Flow_Sensor a owl:Class ;
     rdfs:label "Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
                         owl:onProperty brick:measures ] ) ] ;
     skos:definition "senses or detects flow in a fluid" ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Frost a owl:Class,
-        brick:Frost,
-        brick:Solid ;
+        brick:Frost ;
     rdfs:label "Frost" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Frost ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Frost ) ],
+        brick:Solid ;
     brick:hasAssociatedTag tag:Frost,
         tag:Solid .
 
 brick:Hail a owl:Class,
-        brick:Hail,
-        brick:Solid ;
+        brick:Hail ;
     rdfs:label "Hail" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Hail ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Hail ) ],
+        brick:Solid ;
     brick:hasAssociatedTag tag:Hail,
         tag:Solid .
 
 brick:Heat_Exchanger a owl:Class ;
     rdfs:label "Heat Exchanger" ;
-    rdfs:subClassOf brick:HVAC ;
-    owl:equivalentClass brick:HX .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:HVAC ;
+    owl:equivalentClass brick:HX ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
 
 brick:High_Temperature_Alarm a owl:Class ;
     rdfs:label "High Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_High _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
         tag:High,
+        tag:Point,
         tag:Temperature .
 
 brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
     rdfs:label "Hot Water Return Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
         brick:Return_Water_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Return,
         tag:Sensor,
         tag:Temperature,
@@ -6193,34 +7368,60 @@ brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
 
 brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
     rdfs:label "Hot Water Supply Temperature High Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_High_Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
 
 brick:Humidity_Alarm a owl:Class ;
     rdfs:label "Humidity Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
-        tag:Humidity .
+        tag:Humidity,
+        tag:Point .
 
 brick:Illuminance a owl:Class,
-        brick:Illuminance,
-        brick:Quantity ;
-    rdfs:label "Illuminance" .
+        brick:Illuminance ;
+    rdfs:label "Illuminance" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Interface a owl:Class ;
     rdfs:label "Interface" ;
-    rdfs:subClassOf brick:Lighting_System .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface ) ],
+        brick:Lighting_System ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface .
 
 brick:Irradiance a owl:Class,
-        brick:Irradiance,
-        brick:Quantity ;
-    rdfs:label "Irradiance" .
+        brick:Irradiance ;
+    rdfs:label "Irradiance" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Leaving_Water a owl:Class,
-        brick:Leaving_Water,
-        brick:Water ;
+        brick:Leaving_Water ;
     rdfs:label "Leaving Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Leaving ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Leaving ) ],
+        brick:Water ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Leaving,
         tag:Liquid,
@@ -6239,16 +7440,16 @@ brick:Lighting_System a owl:Class ;
 
 brick:Load_Shed_Command a owl:Class ;
     rdfs:label "Load Shed Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:Load_Shed ;
-                        owl:onProperty brick:hasTag ] _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Load_Shed .
+        tag:Load,
+        tag:Point,
+        tag:Shed .
 
 brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6257,11 +7458,12 @@ brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6269,12 +7471,13 @@ brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -6283,11 +7486,12 @@ brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -6295,24 +7499,26 @@ brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Max_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Max_Limit,
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Cooling Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cooling _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6321,11 +7527,12 @@ brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Cooling Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cooling _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Cooling,
@@ -6333,12 +7540,13 @@ brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Heating Discharge Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heating _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
@@ -6347,11 +7555,12 @@ brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Heating Supply Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heating _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Air_Flow_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
@@ -6359,26 +7568,28 @@ brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Min_Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Min_Limit,
         brick:Static_Pressure_Setpoint_Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Mixed_Air a owl:Class,
-        brick:Air,
         brick:Mixed_Air ;
     rdfs:label "Mixed Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Mixed ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Mixed ) ],
+        brick:Air ;
     skos:definition "(1) air that contains two or more streams of air. (2) combined outdoor air and recirculated air." ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
@@ -6387,47 +7598,50 @@ brick:Mixed_Air a owl:Class,
 
 brick:Occupied_Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Discharge_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint .
 
 brick:Occupied_Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Occupied Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Occupied _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Supply_Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
         tag:Occupied,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
 brick:Oil a owl:Class,
-        brick:Liquid,
         brick:Oil ;
     rdfs:label "Oil" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil ) ],
+        brick:Liquid ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Liquid,
         tag:Oil .
 
 brick:Outside_Air_Lockout_Temperature_Differential_Sensor a owl:Class ;
     rdfs:label "Outside Air Lockout Temperature Differential Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
         brick:Outside_Air_Temperature_Sensor ;
     brick:hasAssociatedTag tag:Air,
         tag:Differential,
         tag:Lockout,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Outside_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Outside Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air _:has_Outside ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Outside ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -6436,88 +7650,110 @@ brick:Outside_Air_Temperature_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Outside,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Overridden_Status a owl:Class ;
     rdfs:label "Overridden Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Overridden _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Overridden,
+        tag:Point,
         tag:Status .
 
+brick:Peak_Power a owl:Class,
+        brick:Peak_Power ;
+    rdfs:label "Peak Power" ;
+    rdfs:subClassOf brick:Power ;
+    skos:definition "Tracks the highest (peak) observed power in some interval" .
+
 brick:Position a owl:Class,
-        brick:Position,
-        brick:Quantity ;
-    rdfs:label "Position" .
+        brick:Position ;
+    rdfs:label "Position" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Position_Limit a owl:Class ;
     rdfs:label "Position Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Limit ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Limit ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
+        tag:Point,
         tag:Position .
 
 brick:Position_Sensor a owl:Class ;
     rdfs:label "Position Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Position _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Sensor ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Position ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Position,
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
         tag:Sensor .
 
 brick:Power_Sensor a owl:Class ;
     rdfs:label "Power Sensor" ;
-    rdfs:subClassOf brick:Sensor ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power ) ],
+        brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Power ;
-                        owl:onProperty brick:measures ] ) ] .
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
+        tag:Sensor .
 
 brick:Pressure_Alarm a owl:Class ;
     rdfs:label "Pressure Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Pressure .
 
 brick:Radiance a owl:Class,
-        brick:Quantity,
         brick:Radiance ;
-    rdfs:label "Radiance" .
+    rdfs:label "Radiance" ;
+    rdfs:subClassOf brick:Quantity .
+
+brick:Reactive_Power a owl:Class,
+        brick:Reactive_Power ;
+    rdfs:label "Reactive Power" ;
+    rdfs:subClassOf brick:Electric_Power .
 
 brick:Real_Power a owl:Class,
-        brick:Electric_Power,
         brick:Real_Power ;
-    rdfs:label "Real Power" .
+    rdfs:label "Real Power" ;
+    rdfs:subClassOf brick:Electric_Power .
 
 brick:Relative_Humidity a owl:Class,
-        brick:Humidity,
         brick:Relative_Humidity ;
-    rdfs:label "Relative Humidity" .
+    rdfs:label "Relative Humidity" ;
+    rdfs:subClassOf brick:Humidity .
 
 brick:Request_Setpoint a owl:Class ;
     rdfs:label "Request Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Request _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Request _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Request,
+    brick:hasAssociatedTag tag:Point,
+        tag:Request,
         tag:Setpoint .
 
 brick:Return_Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Return Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
         tag:Return,
         tag:Temperature .
 
 brick:Return_Water a owl:Class,
-        brick:Return_Water,
-        brick:Water ;
+        brick:Return_Water ;
     rdfs:label "Return Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Return ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Return ) ],
+        brick:Water ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Liquid,
         tag:Return,
@@ -6525,105 +7761,112 @@ brick:Return_Water a owl:Class,
 
 brick:Return_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Return Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Return ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Return ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] [ a owl:Restriction ;
                         owl:hasValue brick:Return_Water ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Return,
+    brick:hasAssociatedTag tag:Point,
+        tag:Return,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Room a owl:Class ;
     rdfs:label "Room" ;
-    rdfs:subClassOf brick:Location .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Room _:has_Location ) ],
+        brick:Location ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room .
 
 brick:Run_Status a owl:Class ;
     rdfs:label "Run Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Run _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Status ) ],
         brick:Start_Stop_Status ;
-    brick:hasAssociatedTag tag:Run,
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
         tag:Status .
 
 brick:Solar_Radiance a owl:Class,
-        brick:Radiance,
         brick:Solar_Radiance ;
-    rdfs:label "Solar Radiance" .
+    rdfs:label "Solar Radiance" ;
+    rdfs:subClassOf brick:Radiance .
 
 brick:Speed_Setpoint a owl:Class ;
     rdfs:label "Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Speed .
 
 brick:Speed_Setpoint_Limit a owl:Class ;
     rdfs:label "Speed Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Static_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Static Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Static_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Static_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Static Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Static,
         tag:Time .
 
 brick:Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Supply Air Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint,
         brick:Temperature_Deadband_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Supply,
         tag:Temperature .
 
 brick:Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Supply Air Temperature Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional,
         tag:Supply,
         tag:Temperature .
 
-brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
-    rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Differential_Reset_Setpoint .
-
 brick:Supply_Hot_Water a owl:Class,
-        brick:Hot_Water,
-        brick:Supply_Hot_Water,
-        brick:Supply_Water ;
+        brick:Supply_Hot_Water ;
     rdfs:label "Supply Hot Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Supply ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Supply ) ],
+        brick:Hot_Water,
+        brick:Supply_Water ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Hot,
         tag:Liquid,
@@ -6632,37 +7875,42 @@ brick:Supply_Hot_Water a owl:Class,
 
 brick:Supply_Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Supply Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Water_Temperature_Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Supply,
         tag:Temperature,
         tag:Water .
 
 brick:System_Enable_Command a owl:Class ;
     rdfs:label "System Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command _:has_System ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_System ) ],
         brick:Enable_Command ;
     brick:hasAssociatedTag tag:Command,
         tag:Enable,
+        tag:Point,
         tag:System .
 
 brick:Temperature_Differential_Reset_Setpoint a owl:Class ;
     rdfs:label "Temperature Differential Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
-
-brick:Temperature_Low_Reset_Setpoint a owl:Class ;
-    rdfs:label "Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Reset_Setpoint .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
 
 brick:Temperature_Sensor a owl:Class ;
     rdfs:label "Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Temperature .
 
 brick:Thermal_Power_Meter a owl:Class ;
@@ -6676,69 +7924,80 @@ brick:Thermal_Power_Meter a owl:Class ;
 
 brick:Time_Parameter a owl:Class ;
     rdfs:label "Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Time ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Time ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Time_Setpoint a owl:Class ;
     rdfs:label "Time Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Time _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Time .
 
 brick:Tolerance_Parameter a owl:Class ;
     rdfs:label "Tolerance Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Tolerance _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Tolerance .
 
 brick:Torque a owl:Class,
-        brick:Quantity,
         brick:Torque ;
-    rdfs:label "Torque" .
+    rdfs:label "Torque" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Unoccupied_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Unoccupied Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Unoccupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature,
         tag:Unoccupied .
 
 brick:Usage_Sensor a owl:Class ;
     rdfs:label "Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage ) ],
         brick:Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Usage .
 
 brick:Variable_Air_Volume_Box a owl:Class ;
     rdfs:label "Variable Air Volume Box" ;
-    rdfs:subClassOf brick:Terminal_Unit ;
-    owl:equivalentClass brick:VAV .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:VAV ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Variable,
+        tag:Volume .
 
 brick:Water_Temperature_Alarm a owl:Class ;
     rdfs:label "Water Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Alarm ) ],
         brick:Temperature_Alarm,
         brick:Water_Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Temperature,
         tag:Water .
 
 brick:Wind_Direction a owl:Class,
-        brick:Direction,
         brick:Wind_Direction ;
-    rdfs:label "Wind Direction" .
+    rdfs:label "Wind Direction" ;
+    rdfs:subClassOf brick:Direction .
 
 brick:Wind_Speed a owl:Class,
-        brick:Speed,
         brick:Wind_Speed ;
-    rdfs:label "Wind Speed" .
+    rdfs:label "Wind Speed" ;
+    rdfs:subClassOf brick:Speed .
 
 brick:feeds a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -6746,8 +8005,14 @@ brick:feeds a owl:AsymmetricProperty,
     owl:inverseOf brick:isFedBy ;
     skos:definition "The subject is upstream of the object in the context of some sequential process; some media is passed between them" .
 
+tag:Absorption a brick:Tag ;
+    rdfs:label "Absorption" .
+
 tag:Acceleration a brick:Tag ;
     rdfs:label "Acceleration" .
+
+tag:Automatic a brick:Tag ;
+    rdfs:label "Automatic" .
 
 tag:Azimuth a brick:Tag ;
     rdfs:label "Azimuth" .
@@ -6758,6 +8023,9 @@ tag:Basement a brick:Tag ;
 tag:Blowdown a brick:Tag ;
     rdfs:label "Blowdown" .
 
+tag:Boiler a brick:Tag ;
+    rdfs:label "Boiler" .
+
 tag:Booster a brick:Tag ;
     rdfs:label "Booster" .
 
@@ -6767,8 +8035,17 @@ tag:Bus a brick:Tag ;
 tag:Button a brick:Tag ;
     rdfs:label "Button" .
 
+tag:CRAC a brick:Tag ;
+    rdfs:label "CRAC" .
+
+tag:CWS a brick:Tag ;
+    rdfs:label "CWS" .
+
 tag:Capacity a brick:Tag ;
     rdfs:label "Capacity" .
+
+tag:Centrifugal a brick:Tag ;
+    rdfs:label "Centrifugal" .
 
 tag:Change a brick:Tag ;
     rdfs:label "Change" .
@@ -6782,14 +8059,23 @@ tag:Close a brick:Tag ;
 tag:Code a brick:Tag ;
     rdfs:label "Code" .
 
+tag:Cold a brick:Tag ;
+    rdfs:label "Cold" .
+
+tag:Coldest a brick:Tag ;
+    rdfs:label "Coldest" .
+
 tag:Communication a brick:Tag ;
     rdfs:label "Communication" .
 
+tag:Compressor a brick:Tag ;
+    rdfs:label "Compressor" .
+
+tag:Computer a brick:Tag ;
+    rdfs:label "Computer" .
+
 tag:Condensate a brick:Tag ;
     rdfs:label "Condensate" .
-
-tag:Condenser a brick:Tag ;
-    rdfs:label "Condenser" .
 
 tag:Contact a brick:Tag ;
     rdfs:label "Contact" .
@@ -6809,8 +8095,14 @@ tag:Deceleration a brick:Tag ;
 tag:Dehumidification a brick:Tag ;
     rdfs:label "Dehumidification" .
 
-tag:Drive a brick:Tag ;
-    rdfs:label "Drive" .
+tag:Detection a brick:Tag ;
+    rdfs:label "Detection" .
+
+tag:Dimmer a brick:Tag ;
+    rdfs:label "Dimmer" .
+
+tag:Driver a brick:Tag ;
+    rdfs:label "Driver" .
 
 tag:Dual a brick:Tag ;
     rdfs:label "Dual" .
@@ -6818,26 +8110,35 @@ tag:Dual a brick:Tag ;
 tag:Econcycle a brick:Tag ;
     rdfs:label "Econcycle" .
 
-tag:Economizer a brick:Tag ;
-    rdfs:label "Economizer" .
+tag:Elevator a brick:Tag ;
+    rdfs:label "Elevator" .
 
-tag:Electrical a brick:Tag ;
-    rdfs:label "Electrical" .
+tag:Environment a brick:Tag ;
+    rdfs:label "Environment" .
+
+tag:Evaporative a brick:Tag ;
+    rdfs:label "Evaporative" .
 
 tag:Even a brick:Tag ;
     rdfs:label "Even" .
 
+tag:FCP a brick:Tag ;
+    rdfs:label "FCP" .
+
+tag:FCU a brick:Tag ;
+    rdfs:label "FCU" .
+
 tag:Floor a brick:Tag ;
     rdfs:label "Floor" .
 
-tag:Freeze a brick:Tag ;
-    rdfs:label "Freeze" .
+tag:Freezer a brick:Tag ;
+    rdfs:label "Freezer" .
 
 tag:Fuel a brick:Tag ;
     rdfs:label "Fuel" .
 
-tag:Fume a brick:Tag ;
-    rdfs:label "Fume" .
+tag:Furniture a brick:Tag ;
+    rdfs:label "Furniture" .
 
 tag:Gasoline a brick:Tag ;
     rdfs:label "Gasoline" .
@@ -6845,23 +8146,29 @@ tag:Gasoline a brick:Tag ;
 tag:Glycool a brick:Tag ;
     rdfs:label "Glycool" .
 
+tag:HWS a brick:Tag ;
+    rdfs:label "HWS" .
+
+tag:HX a brick:Tag ;
+    rdfs:label "HX" .
+
 tag:Hand a brick:Tag ;
     rdfs:label "Hand" .
 
-tag:Highest a brick:Tag ;
-    rdfs:label "Highest" .
+tag:Handler a brick:Tag ;
+    rdfs:label "Handler" .
+
+tag:Head a brick:Tag ;
+    rdfs:label "Head" .
+
+tag:Heater a brick:Tag ;
+    rdfs:label "Heater" .
 
 tag:Hold a brick:Tag ;
     rdfs:label "Hold" .
 
-tag:Hood a brick:Tag ;
-    rdfs:label "Hood" .
-
 tag:Humidification a brick:Tag ;
     rdfs:label "Humidification" .
-
-tag:Humidifier a brick:Tag ;
-    rdfs:label "Humidifier" .
 
 tag:Humidify a brick:Tag ;
     rdfs:label "Humidify" .
@@ -6878,23 +8185,14 @@ tag:Isolation a brick:Tag ;
 tag:Last a brick:Tag ;
     rdfs:label "Last" .
 
-tag:Load_Shed a brick:Tag ;
-    rdfs:label "Load_Shed" .
-
 tag:Locally a brick:Tag ;
     rdfs:label "Locally" .
-
-tag:Maintenance a brick:Tag ;
-    rdfs:label "Maintenance" .
 
 tag:Makeup a brick:Tag ;
     rdfs:label "Makeup" .
 
 tag:Manual a brick:Tag ;
     rdfs:label "Manual" .
-
-tag:Medium a brick:Tag ;
-    rdfs:label "Medium" .
 
 tag:Month a brick:Tag ;
     rdfs:label "Month" .
@@ -6911,9 +8209,6 @@ tag:Natural a brick:Tag ;
 tag:No a brick:Tag ;
     rdfs:label "No" .
 
-tag:OnOff a brick:Tag ;
-    rdfs:label "OnOff" .
-
 tag:Open a brick:Tag ;
     rdfs:label "Open" .
 
@@ -6922,6 +8217,9 @@ tag:Overload a brick:Tag ;
 
 tag:PIR a brick:Tag ;
     rdfs:label "PIR" .
+
+tag:PV a brick:Tag ;
+    rdfs:label "PV" .
 
 tag:Photovoltaic a brick:Tag ;
     rdfs:label "Photovoltaic" .
@@ -6938,8 +8236,17 @@ tag:PlugStrip a brick:Tag ;
 tag:Pre a brick:Tag ;
     rdfs:label "Pre" .
 
+tag:Protect a brick:Tag ;
+    rdfs:label "Protect" .
+
 tag:Push a brick:Tag ;
     rdfs:label "Push" .
+
+tag:RTU a brick:Tag ;
+    rdfs:label "RTU" .
+
+tag:RVAV a brick:Tag ;
+    rdfs:label "RVAV" .
 
 tag:Radiance a brick:Tag ;
     rdfs:label "Radiance" .
@@ -6947,11 +8254,17 @@ tag:Radiance a brick:Tag ;
 tag:Rated a brick:Tag ;
     rdfs:label "Rated" .
 
+tag:Ratio a brick:Tag ;
+    rdfs:label "Ratio" .
+
+tag:Reactive a brick:Tag ;
+    rdfs:label "Reactive" .
+
 tag:Ready a brick:Tag ;
     rdfs:label "Ready" .
 
-tag:Reheat a brick:Tag ;
-    rdfs:label "Reheat" .
+tag:Real a brick:Tag ;
+    rdfs:label "Real" .
 
 tag:Relative a brick:Tag ;
     rdfs:label "Relative" .
@@ -6968,14 +8281,14 @@ tag:Roof a brick:Tag ;
 tag:Rooftop a brick:Tag ;
     rdfs:label "Rooftop" .
 
-tag:Room a brick:Tag ;
-    rdfs:label "Room" .
-
 tag:Sash a brick:Tag ;
     rdfs:label "Sash" .
 
 tag:Schedule a brick:Tag ;
     rdfs:label "Schedule" .
+
+tag:Server a brick:Tag ;
+    rdfs:label "Server" .
 
 tag:Shade a brick:Tag ;
     rdfs:label "Shade" .
@@ -6986,11 +8299,11 @@ tag:Short a brick:Tag ;
 tag:Site a brick:Tag ;
     rdfs:label "Site" .
 
-tag:Space a brick:Tag ;
-    rdfs:label "Space" .
-
 tag:Stages a brick:Tag ;
     rdfs:label "Stages" .
+
+tag:Suction a brick:Tag ;
+    rdfs:label "Suction" .
 
 tag:Tank a brick:Tag ;
     rdfs:label "Tank" .
@@ -6998,11 +8311,20 @@ tag:Tank a brick:Tag ;
 tag:Temporary a brick:Tag ;
     rdfs:label "Temporary" .
 
+tag:Terminal a brick:Tag ;
+    rdfs:label "Terminal" .
+
+tag:Thermostat a brick:Tag ;
+    rdfs:label "Thermostat" .
+
 tag:Timer a brick:Tag ;
     rdfs:label "Timer" .
 
-tag:Today a brick:Tag ;
-    rdfs:label "Today" .
+tag:Touchpanel a brick:Tag ;
+    rdfs:label "Touchpanel" .
+
+tag:Tower a brick:Tag ;
+    rdfs:label "Tower" .
 
 tag:Trace a brick:Tag ;
     rdfs:label "Trace" .
@@ -7010,8 +8332,8 @@ tag:Trace a brick:Tag ;
 tag:Underfloor a brick:Tag ;
     rdfs:label "Underfloor" .
 
-tag:VFD a brick:Tag ;
-    rdfs:label "VFD" .
+tag:VAV a brick:Tag ;
+    rdfs:label "VAV" .
 
 tag:Vent a brick:Tag ;
     rdfs:label "Vent" .
@@ -7019,8 +8341,14 @@ tag:Vent a brick:Tag ;
 tag:Warm a brick:Tag ;
     rdfs:label "Warm" .
 
+tag:Warmest a brick:Tag ;
+    rdfs:label "Warmest" .
+
 tag:Weather a brick:Tag ;
     rdfs:label "Weather" .
+
+tag:Wheel a brick:Tag ;
+    rdfs:label "Wheel" .
 
 tag:Wing a brick:Tag ;
     rdfs:label "Wing" .
@@ -7038,13 +8366,22 @@ brick:AHU a owl:Class ;
     brick:hasAssociatedTag tag:AHU,
         tag:Equipment .
 
+brick:Air_Alarm a owl:Class ;
+    rdfs:label "Air Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm ) ],
+        brick:Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point .
+
 brick:Air_Temperature_Alarm a owl:Class ;
     rdfs:label "Air Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Alarm ) ],
         brick:Air_Alarm,
         brick:Temperature_Alarm ;
     brick:hasAssociatedTag tag:Air,
         tag:Alarm,
+        tag:Point,
         tag:Temperature .
 
 brick:Chilled_Water_System a owl:Class ;
@@ -7058,7 +8395,7 @@ brick:Chilled_Water_System a owl:Class ;
 
 brick:Chilled_Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Chilled Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -7066,35 +8403,37 @@ brick:Chilled_Water_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Chilled_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Water .
 
 brick:Conductivity a owl:Class,
-        brick:Conductivity,
-        brick:Quantity ;
-    rdfs:label "Conductivity" .
+        brick:Conductivity ;
+    rdfs:label "Conductivity" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Current a owl:Class,
-        brick:Current,
-        brick:Quantity ;
-    rdfs:label "Current" .
+        brick:Current ;
+    rdfs:label "Current" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Current_Sensor a owl:Class ;
     rdfs:label "Current Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Current ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Current ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Current ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Current,
+        tag:Point,
         tag:Sensor .
 
 brick:Deionized_Water a owl:Class,
-        brick:Deionized_Water,
-        brick:Water ;
+        brick:Deionized_Water ;
     rdfs:label "Deionized Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Deionized _:has_Water ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Deionized _:has_Water ) ],
+        brick:Water ;
     skos:definition "Water which has been purified by removing its ions (constituting the majority of non-particulate contaminants)" ;
     brick:hasAssociatedTag tag:Deionized,
         tag:Fluid,
@@ -7103,67 +8442,81 @@ brick:Deionized_Water a owl:Class,
 
 brick:Differential_Pressure_Load_Shed_Status a owl:Class ;
     rdfs:label "Differential Pressure Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
         brick:Load_Shed_Status,
         brick:Pressure_Status ;
     brick:hasAssociatedTag tag:Differential,
         tag:Load,
+        tag:Point,
         tag:Pressure,
         tag:Shed,
         tag:Status .
 
 brick:Differential_Speed_Setpoint a owl:Class ;
     rdfs:label "Differential Speed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Speed _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Speed _:has_Setpoint ) ],
         brick:Speed_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Setpoint,
         tag:Speed .
 
 brick:Direction a owl:Class,
-        brick:Direction,
-        brick:Quantity ;
-    rdfs:label "Direction" .
+        brick:Direction ;
+    rdfs:label "Direction" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Duration_Sensor a owl:Class ;
     rdfs:label "Duration Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Duration ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Duration ) ],
         brick:Sensor ;
     brick:hasAssociatedTag tag:Duration,
+        tag:Point,
+        tag:Sensor .
+
+brick:Electrical_Power_Sensor a owl:Class ;
+    rdfs:label "Electrical Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Electrical ) ],
+        brick:Power_Sensor ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
         tag:Sensor .
 
 brick:Fault_Status a owl:Class ;
     rdfs:label "Fault Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fault _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Fault,
+        tag:Point,
         tag:Status .
 
 brick:Fluid a owl:Class,
-        brick:Fluid,
-        brick:Substance ;
+        brick:Fluid ;
     rdfs:label "Fluid" ;
-    rdfs:subClassOf _:has_Fluid ;
+    rdfs:subClassOf _:has_Fluid,
+        brick:Substance ;
     brick:hasAssociatedTag tag:Fluid .
 
 brick:Frequency a owl:Class,
-        brick:Frequency,
-        brick:Quantity ;
-    rdfs:label "Frequency" .
+        brick:Frequency ;
+    rdfs:label "Frequency" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Gain_Parameter a owl:Class ;
     rdfs:label "Gain Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Gain ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Gain,
         tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Hot_Water a owl:Class,
-        brick:Hot_Water,
-        brick:Water ;
+        brick:Hot_Water ;
     rdfs:label "Hot Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot ) ],
+        brick:Water ;
     skos:definition "Hot water used for HVAC heating or supply to hot taps" ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Hot,
@@ -7172,7 +8525,7 @@ brick:Hot_Water a owl:Class,
 
 brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
     rdfs:label "Hot Water Supply Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water _:has_Hot _:has_Supply ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Hot _:has_Supply ) ],
         brick:Water_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -7180,6 +8533,7 @@ brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Supply_Hot_Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Hot,
+        tag:Point,
         tag:Sensor,
         tag:Supply,
         tag:Temperature,
@@ -7196,143 +8550,165 @@ brick:Hot_Water_System a owl:Class ;
 
 brick:Humidity_Parameter a owl:Class ;
     rdfs:label "Humidity Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Humidity _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Humidity,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Load_Shed_Setpoint a owl:Class ;
     rdfs:label "Load Shed Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shed _:has_Load _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shed _:has_Load _:has_Setpoint ) ],
         brick:Load_Setpoint ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Setpoint,
         tag:Shed .
 
 brick:Load_Shed_Status a owl:Class ;
     rdfs:label "Load Shed Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Load _:has_Shed _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Load,
+        tag:Point,
         tag:Shed,
         tag:Status .
 
 brick:Meter a owl:Class ;
     rdfs:label "Meter" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment ) ],
-        brick:Electrical_System ;
+        brick:Equipment ;
     brick:hasAssociatedTag tag:Equipment,
         tag:Meter .
 
 brick:Mode_Command a owl:Class ;
     rdfs:label "Mode Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Mode .
+        tag:Mode,
+        tag:Point .
 
 brick:Mode_Setpoint a owl:Class ;
     rdfs:label "Mode Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Setpoint .
 
 brick:Mode_Status a owl:Class ;
     rdfs:label "Mode Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mode _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Mode,
+        tag:Point,
         tag:Status .
 
 brick:On_Status a owl:Class ;
     rdfs:label "On Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Pressure_Sensor a owl:Class ;
     rdfs:label "Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Pressure ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor .
 
 brick:Pressure_Setpoint a owl:Class ;
     rdfs:label "Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint .
 
 brick:Pressure_Status a owl:Class ;
     rdfs:label "Pressure Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pressure _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Status .
 
+brick:Reset_Command a owl:Class ;
+    rdfs:label "Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Command ) ],
+        brick:Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Reset .
+
 brick:Speed a owl:Class,
-        brick:Quantity,
         brick:Speed ;
-    rdfs:label "Speed" .
+    rdfs:label "Speed" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Speed_Sensor a owl:Class ;
     rdfs:label "Speed Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Speed ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Speed ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Speed .
 
 brick:Static_Pressure_Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Static Pressure Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Proportional,
         tag:Static .
 
 brick:Static_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Static Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Steam_Usage_Sensor a owl:Class ;
     rdfs:label "Steam Usage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Usage _:has_Steam ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Steam ) ],
         brick:Usage_Sensor ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Steam,
         tag:Usage .
 
 brick:Step_Parameter a owl:Class ;
     rdfs:label "Step Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Step ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Step ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Step .
 
 brick:Supply_Chilled_Water a owl:Class,
-        brick:Chilled_Water,
-        brick:Supply_Chilled_Water,
-        brick:Supply_Water ;
+        brick:Supply_Chilled_Water ;
     rdfs:label "Supply Chilled Water" ;
     rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Supply ) ],
+        brick:Chilled_Water,
         brick:Supply_Water ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Fluid,
@@ -7342,49 +8718,75 @@ brick:Supply_Chilled_Water a owl:Class,
 
 brick:System_Status a owl:Class ;
     rdfs:label "System Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_System _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Status,
+    brick:hasAssociatedTag tag:Point,
+        tag:Status,
         tag:System .
 
+brick:Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
 brick:Time a owl:Class,
-        brick:Quantity,
         brick:Time ;
-    rdfs:label "Time" .
+    rdfs:label "Time" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:VFD a owl:Class ;
     rdfs:label "VFD" ;
-    rdfs:subClassOf brick:HVAC .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_VFD ) ],
+        brick:HVAC ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VFD .
 
 brick:Velocity_Pressure_Sensor a owl:Class ;
     rdfs:label "Velocity Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Velocity ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity ) ],
         brick:Pressure_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Velocity_Pressure ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor,
         tag:Velocity .
 
 brick:Voltage a owl:Class,
-        brick:Quantity,
         brick:Voltage ;
-    rdfs:label "Voltage" .
+    rdfs:label "Voltage" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Voltage_Sensor a owl:Class ;
     rdfs:label "Voltage Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Voltage ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Voltage ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Voltage .
 
 brick:Water_Flow_Sensor a owl:Class ;
     rdfs:label "Water Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water ) ],
         brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -7392,12 +8794,17 @@ brick:Water_Flow_Sensor a owl:Class ;
                         owl:hasValue brick:Water ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Flow,
+        tag:Point,
         tag:Sensor,
         tag:Water .
 
 brick:Water_Pump a owl:Class ;
     rdfs:label "Water Pump" ;
-    rdfs:subClassOf brick:Pump .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Water ) ],
+        brick:Pump ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump,
+        tag:Water .
 
 brick:Water_Valve a owl:Class ;
     rdfs:label "Water Valve" ;
@@ -7415,10 +8822,10 @@ brick:Zone a owl:Class ;
         tag:Zone .
 
 brick:Zone_Air a owl:Class,
-        brick:Air,
         brick:Zone_Air ;
     rdfs:label "Zone Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Zone ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Zone ) ],
+        brick:Air ;
     skos:definition "air inside a defined zone (e.g., corridors)." ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
@@ -7434,8 +8841,14 @@ tag:Auto a brick:Tag ;
 tag:Battery a brick:Tag ;
     rdfs:label "Battery" .
 
+tag:Conditioning a brick:Tag ;
+    rdfs:label "Conditioning" .
+
 tag:Conductivity a brick:Tag ;
     rdfs:label "Conductivity" .
+
+tag:Control a brick:Tag ;
+    rdfs:label "Control" .
 
 tag:Cycle a brick:Tag ;
     rdfs:label "Cycle" .
@@ -7452,14 +8865,17 @@ tag:Delay a brick:Tag ;
 tag:Derivative a brick:Tag ;
     rdfs:label "Derivative" .
 
+tag:Drive a brick:Tag ;
+    rdfs:label "Drive" .
+
 tag:Duct a brick:Tag ;
     rdfs:label "Duct" .
 
 tag:Duration a brick:Tag ;
     rdfs:label "Duration" .
 
-tag:Exchanger a brick:Tag ;
-    rdfs:label "Exchanger" .
+tag:Economizer a brick:Tag ;
+    rdfs:label "Economizer" .
 
 tag:Failure a brick:Tag ;
     rdfs:label "Failure" .
@@ -7467,11 +8883,8 @@ tag:Failure a brick:Tag ;
 tag:Fequency a brick:Tag ;
     rdfs:label "Fequency" .
 
-tag:Fire a brick:Tag ;
-    rdfs:label "Fire" .
-
-tag:Frequency a brick:Tag ;
-    rdfs:label "Frequency" .
+tag:Freeze a brick:Tag ;
+    rdfs:label "Freeze" .
 
 tag:Fresh a brick:Tag ;
     rdfs:label "Fresh" .
@@ -7479,14 +8892,23 @@ tag:Fresh a brick:Tag ;
 tag:Frost a brick:Tag ;
     rdfs:label "Frost" .
 
+tag:Fume a brick:Tag ;
+    rdfs:label "Fume" .
+
 tag:Generator a brick:Tag ;
     rdfs:label "Generator" .
 
-tag:HVAC a brick:Tag ;
-    rdfs:label "HVAC" .
-
 tag:Hail a brick:Tag ;
     rdfs:label "Hail" .
+
+tag:Highest a brick:Tag ;
+    rdfs:label "Highest" .
+
+tag:Hood a brick:Tag ;
+    rdfs:label "Hood" .
+
+tag:Humidifier a brick:Tag ;
+    rdfs:label "Humidifier" .
 
 tag:Illuminance a brick:Tag ;
     rdfs:label "Illuminance" .
@@ -7494,14 +8916,14 @@ tag:Illuminance a brick:Tag ;
 tag:Lag a brick:Tag ;
     rdfs:label "Lag" .
 
-tag:Lead a brick:Tag ;
-    rdfs:label "Lead" .
-
-tag:Leak a brick:Tag ;
-    rdfs:label "Leak" .
-
 tag:Lowest a brick:Tag ;
     rdfs:label "Lowest" .
+
+tag:Luminaire a brick:Tag ;
+    rdfs:label "Luminaire" .
+
+tag:Maintenance a brick:Tag ;
+    rdfs:label "Maintenance" .
 
 tag:Oil a brick:Tag ;
     rdfs:label "Oil" .
@@ -7512,35 +8934,63 @@ tag:Operating a brick:Tag ;
 tag:Override a brick:Tag ;
     rdfs:label "Override" .
 
+tag:Peak a brick:Tag ;
+    rdfs:label "Peak" .
+
 tag:Percent a brick:Tag ;
     rdfs:label "Percent" .
 
 tag:Rain a brick:Tag ;
     rdfs:label "Rain" .
 
+tag:Reheat a brick:Tag ;
+    rdfs:label "Reheat" .
+
+tag:Safety a brick:Tag ;
+    rdfs:label "Safety" .
+
+tag:Space a brick:Tag ;
+    rdfs:label "Space" .
+
+tag:Switch a brick:Tag ;
+    rdfs:label "Switch" .
+
+tag:Today a brick:Tag ;
+    rdfs:label "Today" .
+
 tag:Torque a brick:Tag ;
     rdfs:label "Torque" .
+
+tag:Turn a brick:Tag ;
+    rdfs:label "Turn" .
+
+tag:Ventilation a brick:Tag ;
+    rdfs:label "Ventilation" .
+
+tag:Volume a brick:Tag ;
+    rdfs:label "Volume" .
 
 tag:Wind a brick:Tag ;
     rdfs:label "Wind" .
 
 brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Air Temperature Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
         brick:Integral_Time_Parameter,
         brick:Temperature_Parameter ;
     brick:hasAssociatedTag tag:Air,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Temperature,
         tag:Time .
 
 brick:CO2 a owl:Class,
-        brick:CO2,
-        brick:Gas ;
+        brick:CO2 ;
     rdfs:label "CO2" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_CO2 ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_CO2 ) ],
+        brick:Gas ;
     skos:definition "Carbon Dioxide in the vapor phase" ;
     brick:hasAssociatedTag tag:CO2,
         tag:Fluid,
@@ -7548,7 +8998,7 @@ brick:CO2 a owl:Class,
 
 brick:CO2_Sensor a owl:Class ;
     rdfs:label "CO2 Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_CO2 ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_CO2 ) ],
         brick:Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Air ;
@@ -7556,6 +9006,7 @@ brick:CO2_Sensor a owl:Class ;
                         owl:hasValue brick:CO2 ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:CO2,
+        tag:Point,
         tag:Sensor .
 
 brick:Class a owl:Class .
@@ -7570,123 +9021,133 @@ brick:Damper a owl:Class ;
 
 brick:Deadband_Setpoint a owl:Class ;
     rdfs:label "Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deadband _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint .
 
 brick:Demand_Setpoint a owl:Class ;
     rdfs:label "Demand Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Demand _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Demand _:has_Setpoint ) ],
         brick:Setpoint ;
     brick:hasAssociatedTag tag:Demand,
+        tag:Point,
         tag:Setpoint .
 
 brick:Dewpoint a owl:Class,
-        brick:Dewpoint,
-        brick:Quantity ;
-    rdfs:label "Dewpoint" .
+        brick:Dewpoint ;
+    rdfs:label "Dewpoint" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Differential_Pressure_Deadband_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Differential_Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
         tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Differential_Pressure_Integral_Time_Parameter a owl:Class ;
     rdfs:label "Differential Pressure Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
         brick:Integral_Time_Parameter ;
     brick:hasAssociatedTag tag:Differential,
         tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Time .
 
 brick:Differential_Pressure_Proportional_Band a owl:Class ;
     rdfs:label "Differential Pressure Proportional Band" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_PID ) ],
         brick:Proportional_Band_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:Differential,
         tag:PID,
+        tag:Point,
         tag:Pressure,
         tag:Proportional .
 
 brick:Differential_Pressure_Sensor a owl:Class ;
     rdfs:label "Differential Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Differential ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential ) ],
         brick:Pressure_Sensor ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Sensor .
 
 brick:Differential_Pressure_Setpoint a owl:Class ;
     rdfs:label "Differential Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
     brick:hasAssociatedTag tag:Differential,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Differential_Pressure_Setpoint_Limit a owl:Class ;
     rdfs:label "Differential Pressure Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Differential,
         tag:Limit,
         tag:Parameter,
+        tag:Point,
         tag:Pressure,
         tag:Setpoint .
 
 brick:Discharge_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Discharge_Water a owl:Class,
-        brick:Discharge_Water,
-        brick:Water ;
+        brick:Discharge_Water ;
     rdfs:label "Discharge Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Discharge ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Discharge ) ],
+        brick:Water ;
     brick:hasAssociatedTag tag:Discharge,
         tag:Fluid,
         tag:Liquid,
         tag:Water .
 
 brick:Electric_Voltage a owl:Class,
-        brick:Electric_Voltage,
-        brick:Voltage ;
-    rdfs:label "Electric Voltage" .
+        brick:Electric_Voltage ;
+    rdfs:label "Electric Voltage" ;
+    rdfs:subClassOf brick:Voltage .
 
 brick:Emergency_Power_Off_Status a owl:Class ;
     rdfs:label "Emergency Power Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:Status ;
     brick:hasAssociatedTag tag:Emergency,
         tag:Off,
+        tag:Point,
         tag:Power,
         tag:Status .
 
 brick:Energy a owl:Class,
-        brick:Energy,
-        brick:Quantity ;
-    rdfs:label "Energy" .
+        brick:Energy ;
+    rdfs:label "Energy" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Grains a owl:Class,
-        brick:Grains,
-        brick:Quantity ;
-    rdfs:label "Grains" .
+        brick:Grains ;
+    rdfs:label "Grains" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Heating_Valve a owl:Class ;
     rdfs:label "Heating Valve" ;
@@ -7696,22 +9157,22 @@ brick:Heating_Valve a owl:Class ;
         tag:Heat,
         tag:Valve .
 
-brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
-    rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
-    rdfs:subClassOf brick:Temperature_Low_Reset_Setpoint .
-
 brick:Laboratory a owl:Class ;
     rdfs:label "Laboratory" ;
-    rdfs:subClassOf brick:Room .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Room ;
+    brick:hasAssociatedTag tag:Laboratory,
+        tag:Location,
+        tag:Room .
 
 brick:Luminance a owl:Class,
-        brick:Luminance,
-        brick:Quantity ;
-    rdfs:label "Luminance" .
+        brick:Luminance ;
+    rdfs:label "Luminance" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Max Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint_Limit,
         brick:Max_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -7719,80 +9180,106 @@ brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Max,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:Measurable a owl:Class ;
+    rdfs:label "Measurable" ;
     rdfs:subClassOf brick:Class .
 
 brick:Occupancy a owl:Class,
-        brick:Occupancy,
-        brick:Quantity ;
-    rdfs:label "Occupancy" .
+        brick:Occupancy ;
+    rdfs:label "Occupancy" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Off_Status a owl:Class ;
     rdfs:label "Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Status ) ],
         brick:Status ;
     brick:hasAssociatedTag tag:Off,
+        tag:Point,
         tag:Status .
 
 brick:PID_Parameter a owl:Class ;
     rdfs:label "PID Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:PID,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
-brick:Reset_Command a owl:Class ;
-    rdfs:label "Reset Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Command ) ],
-        brick:Command ;
-    brick:hasAssociatedTag tag:Command,
-        tag:Reset .
+brick:Reset_Setpoint a owl:Class ;
+    rdfs:label "Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Setpoints used in Reset strategies" ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Reset,
+        tag:Setpoint .
 
 brick:Solid a owl:Class,
-        brick:Solid,
-        brick:Substance ;
+        brick:Solid ;
     rdfs:label "Solid" ;
-    rdfs:subClassOf _:has_Solid ;
+    rdfs:subClassOf _:has_Solid,
+        brick:Substance ;
     brick:hasAssociatedTag tag:Solid .
 
 brick:Start_Stop_Status a owl:Class ;
     rdfs:label "Start Stop Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Start _:has_Stop _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Status ) ],
         brick:Status ;
-    brick:hasAssociatedTag tag:Start,
+    brick:hasAssociatedTag tag:Point,
+        tag:Start,
         tag:Status,
         tag:Stop .
 
 brick:Static_Pressure_Sensor a owl:Class ;
     rdfs:label "Static Pressure Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Pressure _:has_Static ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static ) ],
         brick:Pressure_Sensor ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Sensor,
         tag:Static .
 
 brick:Supply_Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Supply Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Setpoint,
         tag:Supply .
 
+brick:Supply_Water a owl:Class,
+        brick:Supply_Water ;
+    rdfs:label "Supply Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Supply ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
 brick:Temperature_Alarm a owl:Class ;
     rdfs:label "Temperature Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Temperature .
 
 brick:Terminal_Unit a owl:Class ;
     rdfs:label "Terminal Unit" ;
-    rdfs:subClassOf brick:HVAC ;
-    skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium." .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Terminal ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC ;
+    skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium." ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Terminal,
+        tag:Unit .
 
 brick:Valve a owl:Class ;
     rdfs:label "Valve" ;
@@ -7803,9 +9290,10 @@ brick:Valve a owl:Class ;
 
 brick:Water_Alarm a owl:Class ;
     rdfs:label "Water Alarm" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Alarm ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Alarm ) ],
         brick:Alarm ;
     brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
         tag:Water .
 
 tag:Adjust a brick:Tag ;
@@ -7817,6 +9305,9 @@ tag:Angle a brick:Tag ;
 tag:Bypass a brick:Tag ;
     rdfs:label "Bypass" .
 
+tag:Chiller a brick:Tag ;
+    rdfs:label "Chiller" .
+
 tag:Detected a brick:Tag ;
     rdfs:label "Detected" .
 
@@ -7826,11 +9317,23 @@ tag:Effective a brick:Tag ;
 tag:Entering a brick:Tag ;
     rdfs:label "Entering" .
 
+tag:Frequency a brick:Tag ;
+    rdfs:label "Frequency" .
+
 tag:Grains a brick:Tag ;
     rdfs:label "Grains" .
 
+tag:HVAC a brick:Tag ;
+    rdfs:label "HVAC" .
+
 tag:Ice a brick:Tag ;
     rdfs:label "Ice" .
+
+tag:Lead a brick:Tag ;
+    rdfs:label "Lead" .
+
+tag:Leak a brick:Tag ;
+    rdfs:label "Leak" .
 
 tag:Level a brick:Tag ;
     rdfs:label "Level" .
@@ -7838,40 +9341,31 @@ tag:Level a brick:Tag ;
 tag:Lighting a brick:Tag ;
     rdfs:label "Lighting" .
 
-tag:Mixed a brick:Tag ;
-    rdfs:label "Mixed" .
-
 tag:Overridden a brick:Tag ;
     rdfs:label "Overridden" .
 
-tag:Pump a brick:Tag ;
-    rdfs:label "Pump" .
-
-tag:Shutdown a brick:Tag ;
-    rdfs:label "Shutdown" .
+tag:Panel a brick:Tag ;
+    rdfs:label "Panel" .
 
 tag:Smoke a brick:Tag ;
     rdfs:label "Smoke" .
 
-tag:Standby a brick:Tag ;
-    rdfs:label "Standby" .
-
 tag:Tolerance a brick:Tag ;
     rdfs:label "Tolerance" .
 
-tag:Unit a brick:Tag ;
-    rdfs:label "Unit" .
+tag:Variable a brick:Tag ;
+    rdfs:label "Variable" .
 
 brick:Air_Quality a owl:Class,
-        brick:Air_Quality,
-        brick:Quantity ;
-    rdfs:label "Air Quality" .
+        brick:Air_Quality ;
+    rdfs:label "Air Quality" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Chilled_Water a owl:Class,
-        brick:Chilled_Water,
-        brick:Water ;
+        brick:Chilled_Water ;
     rdfs:label "Chilled Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled ) ],
+        brick:Water ;
     skos:definition "water used as a cooling medium (particularly in air-conditioning systems or in processes) at below ambient temperature." ;
     brick:hasAssociatedTag tag:Chilled,
         tag:Fluid,
@@ -7880,53 +9374,63 @@ brick:Chilled_Water a owl:Class,
 
 brick:Cooling_Temperature_Setpoint a owl:Class ;
     rdfs:label "Cooling Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Cooling,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Disable_Command a owl:Class ;
     rdfs:label "Disable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Disable _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Disable .
+        tag:Disable,
+        tag:Point .
 
 brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Discharge Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Discharge _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
+brick:Electrical_System a owl:Class ;
+    rdfs:label "Electrical System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:System .
+
 brick:Enthalpy a owl:Class,
-        brick:Enthalpy,
-        brick:Quantity ;
+        brick:Enthalpy ;
     rdfs:label "Enthalpy" ;
+    rdfs:subClassOf brick:Quantity ;
     skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)" .
 
 brick:Gas a owl:Class,
-        brick:Fluid,
         brick:Gas ;
     rdfs:label "Gas" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas ) ],
+        brick:Fluid ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Gas .
 
 brick:Liquid a owl:Class,
-        brick:Fluid,
         brick:Liquid ;
     rdfs:label "Liquid" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid ) ],
+        brick:Fluid ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Liquid .
 
 brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
     rdfs:label "Min Air Flow Setpoint Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
         brick:Air_Flow_Setpoint_Limit,
         brick:Min_Limit ;
     brick:hasAssociatedTag tag:Air,
@@ -7934,66 +9438,52 @@ brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
         tag:Limit,
         tag:Min,
         tag:Parameter,
+        tag:Point,
         tag:Setpoint .
 
 brick:On_Off_Command a owl:Class ;
     rdfs:label "On Off Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
-                        owl:hasValue tag:OnOff ;
-                        owl:onProperty brick:hasTag ] _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:OnOff .
+        tag:Off,
+        tag:On,
+        tag:Point .
 
 brick:Outside_Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Outside Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Air_Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Outside,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Power a owl:Class,
-        brick:Power,
-        brick:Quantity ;
-    rdfs:label "Power" .
-
-brick:Reset_Setpoint a owl:Class ;
-    rdfs:label "Reset Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Reset _:has_Setpoint ) ],
-        brick:Setpoint ;
-    brick:hasAssociatedTag tag:Reset,
-        tag:Setpoint .
+        brick:Power ;
+    rdfs:label "Power" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Static_Pressure a owl:Class,
-        brick:Pressure,
         brick:Static_Pressure ;
-    rdfs:label "Static Pressure" .
-
-brick:Supply_Water a owl:Class,
-        brick:Supply_Water,
-        brick:Water ;
-    rdfs:label "Supply Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Supply ) ] ;
-    brick:hasAssociatedTag tag:Fluid,
-        tag:Liquid,
-        tag:Supply,
-        tag:Water .
+    rdfs:label "Static Pressure" ;
+    rdfs:subClassOf brick:Pressure .
 
 brick:Temperature_Deadband_Setpoint a owl:Class ;
     rdfs:label "Temperature Deadband Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
         brick:Deadband_Setpoint,
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Velocity_Pressure a owl:Class,
-        brick:Pressure,
         brick:Velocity_Pressure ;
-    rdfs:label "Velocity Pressure" .
+    rdfs:label "Velocity Pressure" ;
+    rdfs:subClassOf brick:Pressure .
 
 brick:Water_System a owl:Class ;
     rdfs:label "Water System" ;
@@ -8004,15 +9494,16 @@ brick:Water_System a owl:Class ;
 
 brick:Water_Temperature_Setpoint a owl:Class ;
     rdfs:label "Water Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Setpoint ) ],
         brick:Temperature_Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Temperature,
         tag:Water .
 
 brick:Zone_Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Zone Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
         brick:Air_Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -8020,6 +9511,7 @@ brick:Zone_Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Zone_Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature,
         tag:Zone .
@@ -8030,41 +9522,32 @@ tag:Average a brick:Tag ;
 tag:Building a brick:Tag ;
     rdfs:label "Building" .
 
-tag:Coil a brick:Tag ;
-    rdfs:label "Coil" .
+tag:Condenser a brick:Tag ;
+    rdfs:label "Condenser" .
 
 tag:Dewpoint a brick:Tag ;
     rdfs:label "Dewpoint" .
 
-tag:Fault a brick:Tag ;
-    rdfs:label "Fault" .
-
-tag:Filter a brick:Tag ;
-    rdfs:label "Filter" .
-
 tag:Fixed a brick:Tag ;
     rdfs:label "Fixed" .
+
+tag:Interface a brick:Tag ;
+    rdfs:label "Interface" .
 
 tag:Leaving a brick:Tag ;
     rdfs:label "Leaving" .
 
-tag:Loss a brick:Tag ;
-    rdfs:label "Loss" .
-
 tag:Luminance a brick:Tag ;
     rdfs:label "Luminance" .
+
+tag:Mixed a brick:Tag ;
+    rdfs:label "Mixed" .
 
 tag:Occupancy a brick:Tag ;
     rdfs:label "Occupancy" .
 
-tag:Output a brick:Tag ;
-    rdfs:label "Output" .
-
-tag:Preheat a brick:Tag ;
-    rdfs:label "Preheat" .
-
-tag:Reset a brick:Tag ;
-    rdfs:label "Reset" .
+tag:Shutdown a brick:Tag ;
+    rdfs:label "Shutdown" .
 
 tag:Solar a brick:Tag ;
     rdfs:label "Solar" .
@@ -8072,47 +9555,40 @@ tag:Solar a brick:Tag ;
 tag:Solid a brick:Tag ;
     rdfs:label "Solid" .
 
-tag:Start a brick:Tag ;
-    rdfs:label "Start" .
-
-tag:Stop a brick:Tag ;
-    rdfs:label "Stop" .
-
 tag:Storage a brick:Tag ;
     rdfs:label "Storage" .
+
+tag:VFD a brick:Tag ;
+    rdfs:label "VFD" .
 
 tag:Voltage a brick:Tag ;
     rdfs:label "Voltage" .
 
 brick:Discharge_Air a owl:Class,
-        brick:Air,
         brick:Discharge_Air ;
     rdfs:label "Discharge Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Discharge ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Discharge ) ],
+        brick:Air ;
     brick:hasAssociatedTag tag:Air,
         tag:Discharge,
         tag:Fluid,
         tag:Gas .
 
 brick:Electric_Current a owl:Class,
-        brick:Current,
         brick:Electric_Current ;
-    rdfs:label "Electric Current" .
+    rdfs:label "Electric Current" ;
+    rdfs:subClassOf brick:Current .
 
 brick:Electric_Power a owl:Class,
-        brick:Electric_Power,
-        brick:Power ;
-    rdfs:label "Electric Power" .
-
-brick:Electrical_System a owl:Class ;
-    rdfs:label "Electrical System" ;
-    rdfs:subClassOf brick:Equipment .
+        brick:Electric_Power ;
+    rdfs:label "Electric Power" ;
+    rdfs:subClassOf brick:Power .
 
 brick:Exhaust_Air a owl:Class,
-        brick:Air,
         brick:Exhaust_Air ;
     rdfs:label "Exhaust Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Exhaust ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Exhaust ) ],
+        brick:Air ;
     skos:definition "air that must be removed from a space due to contaminants, regardless of pressurization" ;
     brick:hasAssociatedTag tag:Air,
         tag:Exhaust,
@@ -8129,19 +9605,21 @@ brick:Fan a owl:Class ;
 
 brick:Heating_Temperature_Setpoint a owl:Class ;
     rdfs:label "Heating Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint _:has_Heating ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Heating ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Heating,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Integral_Time_Parameter a owl:Class ;
     rdfs:label "Integral Time Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
         brick:Time_Parameter ;
     brick:hasAssociatedTag tag:Integral,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Time .
 
 brick:Substance a owl:Class ;
@@ -8149,10 +9627,10 @@ brick:Substance a owl:Class ;
         brick:Measurable .
 
 brick:Supply_Air a owl:Class,
-        brick:Air,
         brick:Supply_Air ;
     rdfs:label "Supply Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Supply ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Supply ) ],
+        brick:Air ;
     skos:definition "(1) air delivered by mechanical or natural ventilation to a space, composed of any combination of outdoor air, recirculated air, or transfer air. (2) air entering a space from an air-conditioning, heating, or ventilating apparatus for the purpose of comfort conditioning. Supply air is generally filtered, fan forced, and either heated, cooled, humidified, or dehumidified as necessary to maintain specified conditions. Only the quantity of outdoor air within the supply airflow may be used as replacement air." ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
@@ -8161,35 +9639,63 @@ brick:Supply_Air a owl:Class,
 
 brick:Temperature_Setpoint a owl:Class ;
     rdfs:label "Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint ) ],
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Setpoint,
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
         tag:Temperature .
 
-tag:Cool a brick:Tag ;
-    rdfs:label "Cool" .
+tag:Coil a brick:Tag ;
+    rdfs:label "Coil" .
 
 tag:Direction a brick:Tag ;
     rdfs:label "Direction" .
 
-tag:Energy a brick:Tag ;
-    rdfs:label "Energy" .
+tag:Electrical a brick:Tag ;
+    rdfs:label "Electrical" .
+
+tag:Exchanger a brick:Tag ;
+    rdfs:label "Exchanger" .
+
+tag:Fault a brick:Tag ;
+    rdfs:label "Fault" .
+
+tag:Laboratory a brick:Tag ;
+    rdfs:label "Laboratory" .
 
 tag:Lockout a brick:Tag ;
     rdfs:label "Lockout" .
 
+tag:Loss a brick:Tag ;
+    rdfs:label "Loss" .
+
 tag:Motor a brick:Tag ;
     rdfs:label "Motor" .
 
+tag:Output a brick:Tag ;
+    rdfs:label "Output" .
+
+tag:Preheat a brick:Tag ;
+    rdfs:label "Preheat" .
+
 tag:Stack a brick:Tag ;
     rdfs:label "Stack" .
+
+tag:Standby a brick:Tag ;
+    rdfs:label "Standby" .
+
+tag:Start a brick:Tag ;
+    rdfs:label "Start" .
+
+tag:Stop a brick:Tag ;
+    rdfs:label "Stop" .
 
 tag:Velocity a brick:Tag ;
     rdfs:label "Velocity" .
 
 brick:Air_Flow_Sensor a owl:Class ;
     rdfs:label "Air Flow Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Flow _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air ) ],
         brick:Flow_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Flow ;
@@ -8198,19 +9704,21 @@ brick:Air_Flow_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Sensor .
 
 brick:Air_Flow_Setpoint a owl:Class ;
     rdfs:label "Air Flow Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Flow _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Setpoint ) ],
         brick:Flow_Setpoint ;
     brick:hasAssociatedTag tag:Air,
         tag:Flow,
+        tag:Point,
         tag:Setpoint .
 
 brick:Air_Humidity_Sensor a owl:Class ;
     rdfs:label "Air Humidity Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Humidity _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air ) ],
         brick:Humidity_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Humidity ;
@@ -8219,45 +9727,58 @@ brick:Air_Humidity_Sensor a owl:Class ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
         tag:Humidity,
+        tag:Point,
         tag:Sensor .
 
 brick:Level a owl:Class,
-        brick:Level,
-        brick:Quantity ;
-    rdfs:label "Level" .
+        brick:Level ;
+    rdfs:label "Level" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Proportional_Band_Parameter a owl:Class ;
     rdfs:label "Proportional Band Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
         brick:PID_Parameter ;
     brick:hasAssociatedTag tag:Band,
         tag:PID,
         tag:Parameter,
+        tag:Point,
         tag:Proportional .
 
 brick:Static_Pressure_Setpoint a owl:Class ;
     rdfs:label "Static Pressure Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Static _:has_Pressure _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Setpoint ) ],
         brick:Pressure_Setpoint ;
-    brick:hasAssociatedTag tag:Pressure,
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
         tag:Setpoint,
         tag:Static .
 
 brick:Water_Temperature_Sensor a owl:Class ;
     rdfs:label "Water Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Water ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water ) ],
         brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
                         owl:onProperty brick:measures ] [ a owl:Restriction ;
                         owl:hasValue brick:Water ;
                         owl:onProperty brick:measures ] ) ] ;
-    brick:hasAssociatedTag tag:Sensor,
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
         tag:Temperature,
         tag:Water .
 
-tag:Current a brick:Tag ;
-    rdfs:label "Current" .
+tag:Box a brick:Tag ;
+    rdfs:label "Box" .
+
+tag:Cool a brick:Tag ;
+    rdfs:label "Cool" .
+
+tag:Energy a brick:Tag ;
+    rdfs:label "Energy" .
+
+tag:Fire a brick:Tag ;
+    rdfs:label "Fire" .
 
 tag:Gain a brick:Tag ;
     rdfs:label "Gain" .
@@ -8265,9 +9786,12 @@ tag:Gain a brick:Tag ;
 tag:Run a brick:Tag ;
     rdfs:label "Run" .
 
+tag:Unit a brick:Tag ;
+    rdfs:label "Unit" .
+
 brick:Air_Temperature_Sensor a owl:Class ;
     rdfs:label "Air Temperature Sensor" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Sensor _:has_Temperature _:has_Air ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air ) ],
         brick:Temperature_Sensor ;
     owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
                         owl:hasValue brick:Temperature ;
@@ -8275,31 +9799,34 @@ brick:Air_Temperature_Sensor a owl:Class ;
                         owl:hasValue brick:Air ;
                         owl:onProperty brick:measures ] ) ] ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Sensor,
         tag:Temperature .
 
 brick:Enable_Command a owl:Class ;
     rdfs:label "Enable Command" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enable _:has_Command ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command ) ],
         brick:Command ;
     brick:hasAssociatedTag tag:Command,
-        tag:Enable .
+        tag:Enable,
+        tag:Point .
 
 brick:On_Off_Status a owl:Class ;
     rdfs:label "On Off Status" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_On _:has_Off _:has_Status ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Status ) ],
         brick:Off_Status,
         brick:On_Status,
         brick:Status ;
     brick:hasAssociatedTag tag:Off,
         tag:On,
+        tag:Point,
         tag:Status .
 
 brick:Outside_Air a owl:Class,
-        brick:Air,
         brick:Outside_Air ;
     rdfs:label "Outside Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Outside ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Outside ) ],
+        brick:Air ;
     skos:definition "air external to a defined zone (e.g., corridors)." ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
@@ -8307,32 +9834,32 @@ brick:Outside_Air a owl:Class,
         tag:Outside .
 
 brick:Pressure a owl:Class,
-        brick:Pressure,
-        brick:Quantity ;
-    rdfs:label "Pressure" .
+        brick:Pressure ;
+    rdfs:label "Pressure" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Return_Air a owl:Class,
-        brick:Air,
         brick:Return_Air ;
     rdfs:label "Return Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Return ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Return ) ],
+        brick:Air ;
     skos:definition "air removed from a space to be recirculated or exhausted. Air extracted from a space and totally or partially returned to an air conditioner, furnace, or other heating, cooling, or ventilating system." ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
         tag:Gas,
         tag:Return .
 
-tag:Disable a brick:Tag ;
-    rdfs:label "Disable" .
+tag:Current a brick:Tag ;
+    rdfs:label "Current" .
 
 tag:Domestic a brick:Tag ;
     rdfs:label "Domestic" .
 
+tag:Filter a brick:Tag ;
+    rdfs:label "Filter" .
+
 tag:Request a brick:Tag ;
     rdfs:label "Request" .
-
-tag:Steam a brick:Tag ;
-    rdfs:label "Steam" .
 
 tag:Thermal a brick:Tag ;
     rdfs:label "Thermal" .
@@ -8342,53 +9869,59 @@ tag:Usage a brick:Tag ;
 
 brick:Air_Temperature_Setpoint a owl:Class ;
     rdfs:label "Air Temperature Setpoint" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Temperature _:has_Setpoint ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Setpoint ) ],
         brick:Temperature_Setpoint ;
     brick:hasAssociatedTag tag:Air,
+        tag:Point,
         tag:Setpoint,
         tag:Temperature .
 
 brick:Max_Limit a owl:Class ;
     rdfs:label "Max Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Max _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Max,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
-tag:Demand a brick:Tag ;
-    rdfs:label "Demand" .
-
-tag:Emergency a brick:Tag ;
-    rdfs:label "Emergency" .
-
-tag:Low a brick:Tag ;
-    rdfs:label "Low" .
+tag:Disable a brick:Tag ;
+    rdfs:label "Disable" .
 
 tag:Meter a brick:Tag ;
     rdfs:label "Meter" .
 
-tag:System a brick:Tag ;
-    rdfs:label "System" .
+tag:Pump a brick:Tag ;
+    rdfs:label "Pump" .
+
+tag:Steam a brick:Tag ;
+    rdfs:label "Steam" .
 
 brick:Humidity a owl:Class,
-        brick:Humidity,
-        brick:Quantity ;
-    rdfs:label "Humidity" .
+        brick:Humidity ;
+    rdfs:label "Humidity" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Min_Limit a owl:Class ;
     rdfs:label "Min Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Min _:has_Limit _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Limit _:has_Parameter ) ],
         brick:Limit ;
     brick:hasAssociatedTag tag:Limit,
         tag:Min,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Point a owl:Class ;
-    rdfs:subClassOf brick:Class .
+    rdfs:label "Point" ;
+    rdfs:subClassOf _:has_Point,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Point .
 
 tag:Damper a brick:Tag ;
     rdfs:label "Damper" .
+
+tag:Demand a brick:Tag ;
+    rdfs:label "Demand" .
 
 tag:Enthalpy a brick:Tag ;
     rdfs:label "Enthalpy" .
@@ -8396,112 +9929,105 @@ tag:Enthalpy a brick:Tag ;
 tag:Position a brick:Tag ;
     rdfs:label "Position" .
 
-tag:High a brick:Tag ;
-    rdfs:label "High" .
-
-tag:Mode a brick:Tag ;
-    rdfs:label "Mode" .
+tag:Room a brick:Tag ;
+    rdfs:label "Room" .
 
 tag:Step a brick:Tag ;
     rdfs:label "Step" .
 
 brick:Limit a owl:Class ;
     rdfs:label "Limit" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parameter _:has_Limit ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Limit ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Limit,
-        tag:Parameter .
+        tag:Parameter,
+        tag:Point .
 
 brick:Location a owl:Class ;
+    rdfs:label "Location" ;
     rdfs:subClassOf _:has_Location,
         brick:Class ;
     brick:hasAssociatedTag tag:Location .
 
 brick:Parameter a owl:Class ;
     rdfs:label "Parameter" ;
-    rdfs:subClassOf _:has_Parameter,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Parameter .
-
-tag:Heat a brick:Tag ;
-    rdfs:label "Heat" .
-
-tag:Shed a brick:Tag ;
-    rdfs:label "Shed" .
-
-tag:Zone a brick:Tag ;
-    rdfs:label "Zone" .
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point .
 
 tag:CO2 a brick:Tag ;
     rdfs:label "CO2" .
 
-tag:Unoccupied a brick:Tag ;
-    rdfs:label "Unoccupied" .
+tag:Emergency a brick:Tag ;
+    rdfs:label "Emergency" .
 
-brick:Equipment a owl:Class ;
-    rdfs:subClassOf _:has_Equipment,
-        brick:Class ;
-    brick:hasAssociatedTag tag:Equipment .
+tag:Medium a brick:Tag ;
+    rdfs:label "Medium" .
 
 brick:Temperature_Parameter a owl:Class ;
     rdfs:label "Temperature Parameter" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Temperature _:has_Parameter ) ],
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Parameter ) ],
         brick:Parameter ;
     brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
         tag:Temperature .
 
-tag:Location a brick:Tag ;
-    rdfs:label "Location" .
+tag:Mode a brick:Tag ;
+    rdfs:label "Mode" .
 
-tag:On a brick:Tag ;
-    rdfs:label "On" .
-
-tag:Power a brick:Tag ;
-    rdfs:label "Power" .
+tag:System a brick:Tag ;
+    rdfs:label "System" .
 
 tag:Valve a brick:Tag ;
     rdfs:label "Valve" .
 
+brick:Equipment a owl:Class ;
+    rdfs:label "Equipment" ;
+    rdfs:subClassOf _:has_Equipment,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Equipment .
+
 brick:Flow a owl:Class,
-        brick:Flow,
-        brick:Quantity ;
-    rdfs:label "Flow" .
-
-tag:Off a brick:Tag ;
-    rdfs:label "Off" .
-
-tag:Speed a brick:Tag ;
-    rdfs:label "Speed" .
+        brick:Flow ;
+    rdfs:label "Flow" ;
+    rdfs:subClassOf brick:Quantity .
 
 brick:Water a owl:Class,
-        brick:Liquid,
         brick:Water ;
     rdfs:label "Water" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water ) ],
+        brick:Liquid ;
     skos:definition "transparent, odorless, tasteless liquid; a compound of hydrogen and oxygen (H2O), containing 11.188% hydrogen and 88.812% oxygen by mass; freezing at 32°F (0°C); boiling near 212°F (100°C)." ;
     brick:hasAssociatedTag tag:Fluid,
         tag:Liquid,
         tag:Water .
 
-tag:Fan a brick:Tag ;
-    rdfs:label "Fan" .
-
 tag:Gas a brick:Tag ;
     rdfs:label "Gas" .
 
-tag:Load a brick:Tag ;
-    rdfs:label "Load" .
+tag:Heat a brick:Tag ;
+    rdfs:label "Heat" .
+
+tag:Speed a brick:Tag ;
+    rdfs:label "Speed" .
+
+tag:Unoccupied a brick:Tag ;
+    rdfs:label "Unoccupied" .
+
+tag:Zone a brick:Tag ;
+    rdfs:label "Zone" .
 
 brick:Air a owl:Class,
-        brick:Air,
-        brick:Gas ;
+        brick:Air ;
     rdfs:label "Air" ;
-    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air ) ] ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air ) ],
+        brick:Gas ;
     brick:hasAssociatedTag tag:Air,
         tag:Fluid,
         tag:Gas .
@@ -8509,8 +10035,8 @@ brick:Air a owl:Class,
 tag:Humidity a brick:Tag ;
     rdfs:label "Humidity" .
 
-tag:Enable a brick:Tag ;
-    rdfs:label "Enable" .
+tag:Low a brick:Tag ;
+    rdfs:label "Low" .
 
 tag:Occupied a brick:Tag ;
     rdfs:label "Occupied" .
@@ -8518,164 +10044,202 @@ tag:Occupied a brick:Tag ;
 tag:Integral a brick:Tag ;
     rdfs:label "Integral" .
 
+tag:On a brick:Tag ;
+    rdfs:label "On" .
+
+tag:Fan a brick:Tag ;
+    rdfs:label "Fan" .
+
+tag:Location a brick:Tag ;
+    rdfs:label "Location" .
+
 brick:Setpoint a owl:Class ;
     rdfs:label "Setpoint" ;
-    rdfs:subClassOf _:has_Setpoint,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Status ;
-    brick:hasAssociatedTag tag:Setpoint .
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint .
 
 brick:Temperature a owl:Class,
-        brick:Quantity,
         brick:Temperature ;
-    rdfs:label "Temperature" .
+    rdfs:label "Temperature" ;
+    rdfs:subClassOf brick:Quantity .
 
 tag:Band a brick:Tag ;
     rdfs:label "Band" .
 
-tag:Return a brick:Tag ;
-    rdfs:label "Return" .
+tag:Enable a brick:Tag ;
+    rdfs:label "Enable" .
+
+tag:High a brick:Tag ;
+    rdfs:label "High" .
+
+tag:Power a brick:Tag ;
+    rdfs:label "Power" .
+
+tag:Shed a brick:Tag ;
+    rdfs:label "Shed" .
 
 brick:Alarm a owl:Class ;
     rdfs:label "Alarm" ;
-    rdfs:subClassOf _:has_Alarm,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm ) ],
         brick:Point ;
     owl:disjointWith brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Alarm .
-
-tag:Exhaust a brick:Tag ;
-    rdfs:label "Exhaust" .
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point .
 
 tag:Liquid a brick:Tag ;
     rdfs:label "Liquid" .
 
-tag:Outside a brick:Tag ;
-    rdfs:label "Outside" .
-
 tag:Proportional a brick:Tag ;
     rdfs:label "Proportional" .
+
+tag:Return a brick:Tag ;
+    rdfs:label "Return" .
 
 tag:Time a brick:Tag ;
     rdfs:label "Time" .
 
 brick:HVAC a owl:Class ;
     rdfs:label "HVAC" ;
-    rdfs:subClassOf brick:Equipment ;
-    owl:equivalentClass brick:Heating_Ventilation_Air_Conditioning_System .
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heating _:has_Ventilation _:has_Air _:has_Conditioning _:has_System ) ],
+        brick:Equipment ;
+    owl:equivalentClass brick:Heating_Ventilation_Air_Conditioning_System ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Conditioning,
+        tag:Heating,
+        tag:System,
+        tag:Ventilation .
 
 tag:Deadband a brick:Tag ;
     rdfs:label "Deadband" .
 
+tag:Exhaust a brick:Tag ;
+    rdfs:label "Exhaust" .
+
+tag:Off a brick:Tag ;
+    rdfs:label "Off" .
+
+tag:Load a brick:Tag ;
+    rdfs:label "Load" .
+
 tag:Min a brick:Tag ;
     rdfs:label "Min" .
 
-tag:Max a brick:Tag ;
-    rdfs:label "Max" .
+tag:Outside a brick:Tag ;
+    rdfs:label "Outside" .
 
 brick:Command a owl:Class ;
     rdfs:label "Command" ;
-    rdfs:subClassOf _:has_Command,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Command ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Command .
+    brick:hasAssociatedTag tag:Command,
+        tag:Point .
+
+tag:Max a brick:Tag ;
+    rdfs:label "Max" .
 
 tag:Chilled a brick:Tag ;
     rdfs:label "Chilled" .
 
-tag:Hot a brick:Tag ;
-    rdfs:label "Hot" .
+tag:Reset a brick:Tag ;
+    rdfs:label "Reset" .
 
 brick:Quantity a owl:Class ;
     rdfs:subClassOf sosa:ObservableProperty,
         brick:Measurable .
 
-tag:Cooling a brick:Tag ;
-    rdfs:label "Cooling" .
-
 brick:Status a owl:Class ;
     rdfs:label "Status" ;
-    rdfs:subClassOf _:has_Status,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Status ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Sensor,
         brick:Setpoint ;
-    brick:hasAssociatedTag tag:Status .
+    brick:hasAssociatedTag tag:Point,
+        tag:Status .
 
-tag:Heating a brick:Tag ;
-    rdfs:label "Heating" .
+tag:Cooling a brick:Tag ;
+    rdfs:label "Cooling" .
 
 tag:Fluid a brick:Tag ;
     rdfs:label "Fluid" .
+
+tag:Heating a brick:Tag ;
+    rdfs:label "Heating" .
 
 tag:Static a brick:Tag ;
     rdfs:label "Static" .
 
 brick:Sensor a owl:Class ;
     rdfs:label "Sensor" ;
-    rdfs:subClassOf _:has_Sensor,
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor ) ],
         brick:Point ;
     owl:disjointWith brick:Alarm,
         brick:Command,
         brick:Parameter,
         brick:Setpoint,
         brick:Status ;
-    brick:hasAssociatedTag tag:Sensor .
-
-tag:Command a brick:Tag ;
-    rdfs:label "Command" .
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor .
 
 tag:PID a brick:Tag ;
     rdfs:label "PID" .
 
+tag:Hot a brick:Tag ;
+    rdfs:label "Hot" .
+
 tag:Alarm a brick:Tag ;
     rdfs:label "Alarm" .
-
-tag:Equipment a brick:Tag ;
-    rdfs:label "Equipment" .
-
-tag:Differential a brick:Tag ;
-    rdfs:label "Differential" .
 
 tag:Limit a brick:Tag ;
     rdfs:label "Limit" .
 
-tag:Discharge a brick:Tag ;
-    rdfs:label "Discharge" .
+tag:Command a brick:Tag ;
+    rdfs:label "Command" .
+
+tag:Differential a brick:Tag ;
+    rdfs:label "Differential" .
 
 tag:Status a brick:Tag ;
     rdfs:label "Status" .
 
-tag:Supply a brick:Tag ;
-    rdfs:label "Supply" .
+tag:Discharge a brick:Tag ;
+    rdfs:label "Discharge" .
 
 tag:Flow a brick:Tag ;
     rdfs:label "Flow" .
 
+tag:Supply a brick:Tag ;
+    rdfs:label "Supply" .
+
 tag:Pressure a brick:Tag ;
     rdfs:label "Pressure" .
 
-tag:Water a brick:Tag ;
-    rdfs:label "Water" .
+tag:Equipment a brick:Tag ;
+    rdfs:label "Equipment" .
 
 tag:Parameter a brick:Tag ;
     rdfs:label "Parameter" .
 
-tag:Temperature a brick:Tag ;
-    rdfs:label "Temperature" .
+tag:Water a brick:Tag ;
+    rdfs:label "Water" .
 
 brick:measures a owl:AsymmetricProperty,
         owl:IrreflexiveProperty,
@@ -8684,6 +10248,9 @@ brick:measures a owl:AsymmetricProperty,
     rdfs:range brick:Measurable ;
     owl:inverseOf brick:isMeasuredBy ;
     skos:definition "The subject measures a quantity or substance given by the object" .
+
+tag:Temperature a brick:Tag ;
+    rdfs:label "Temperature" .
 
 tag:Sensor a brick:Tag ;
     rdfs:label "Sensor" .
@@ -8705,6 +10272,9 @@ brick:Tag a owl:AllDifferent,
         owl:Class ;
     owl:distinctMembers ( tag:Coil tag:Valve tag:Heat tag:Cool tag:Equipment tag:Location tag:Point tag:Lighting tag:HVAC tag:Air tag:Steam tag:Ice tag:Chilled ) .
 
+tag:Point a brick:Tag ;
+    rdfs:label "Point" .
+
 [] a owl:Restriction ;
     owl:hasValue tag:Pir ;
     owl:onProperty brick:hasTag .
@@ -8721,8 +10291,16 @@ _:has_Battery a owl:Restriction ;
     owl:hasValue tag:Battery ;
     owl:onProperty brick:hasTag .
 
+_:has_Conditioning a owl:Restriction ;
+    owl:hasValue tag:Conditioning ;
+    owl:onProperty brick:hasTag .
+
 _:has_Conductivity a owl:Restriction ;
     owl:hasValue tag:Conductivity ;
+    owl:onProperty brick:hasTag .
+
+_:has_Control a owl:Restriction ;
+    owl:hasValue tag:Control ;
     owl:onProperty brick:hasTag .
 
 _:has_Cycle a owl:Restriction ;
@@ -8745,6 +10323,10 @@ _:has_Derivative a owl:Restriction ;
     owl:hasValue tag:Derivative ;
     owl:onProperty brick:hasTag .
 
+_:has_Drive a owl:Restriction ;
+    owl:hasValue tag:Drive ;
+    owl:onProperty brick:hasTag .
+
 _:has_Duct a owl:Restriction ;
     owl:hasValue tag:Duct ;
     owl:onProperty brick:hasTag .
@@ -8753,8 +10335,8 @@ _:has_Duration a owl:Restriction ;
     owl:hasValue tag:Duration ;
     owl:onProperty brick:hasTag .
 
-_:has_Exchanger a owl:Restriction ;
-    owl:hasValue tag:Exchanger ;
+_:has_Economizer a owl:Restriction ;
+    owl:hasValue tag:Economizer ;
     owl:onProperty brick:hasTag .
 
 _:has_Failure a owl:Restriction ;
@@ -8765,12 +10347,8 @@ _:has_Fequency a owl:Restriction ;
     owl:hasValue tag:Fequency ;
     owl:onProperty brick:hasTag .
 
-_:has_Fire a owl:Restriction ;
-    owl:hasValue tag:Fire ;
-    owl:onProperty brick:hasTag .
-
-_:has_Frequency a owl:Restriction ;
-    owl:hasValue tag:Frequency ;
+_:has_Freeze a owl:Restriction ;
+    owl:hasValue tag:Freeze ;
     owl:onProperty brick:hasTag .
 
 _:has_Fresh a owl:Restriction ;
@@ -8781,12 +10359,32 @@ _:has_Frost a owl:Restriction ;
     owl:hasValue tag:Frost ;
     owl:onProperty brick:hasTag .
 
+_:has_Fume a owl:Restriction ;
+    owl:hasValue tag:Fume ;
+    owl:onProperty brick:hasTag .
+
 _:has_Generator a owl:Restriction ;
     owl:hasValue tag:Generator ;
     owl:onProperty brick:hasTag .
 
+_:has_HVAC a owl:Restriction ;
+    owl:hasValue tag:HVAC ;
+    owl:onProperty brick:hasTag .
+
 _:has_Hail a owl:Restriction ;
     owl:hasValue tag:Hail ;
+    owl:onProperty brick:hasTag .
+
+_:has_Highest a owl:Restriction ;
+    owl:hasValue tag:Highest ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hood a owl:Restriction ;
+    owl:hasValue tag:Hood ;
+    owl:onProperty brick:hasTag .
+
+_:has_Humidifier a owl:Restriction ;
+    owl:hasValue tag:Humidifier ;
     owl:onProperty brick:hasTag .
 
 _:has_Ice a owl:Restriction ;
@@ -8801,20 +10399,20 @@ _:has_Lag a owl:Restriction ;
     owl:hasValue tag:Lag ;
     owl:onProperty brick:hasTag .
 
-_:has_Lead a owl:Restriction ;
-    owl:hasValue tag:Lead ;
-    owl:onProperty brick:hasTag .
-
-_:has_Leak a owl:Restriction ;
-    owl:hasValue tag:Leak ;
-    owl:onProperty brick:hasTag .
-
 _:has_Lighting a owl:Restriction ;
     owl:hasValue tag:Lighting ;
     owl:onProperty brick:hasTag .
 
 _:has_Lowest a owl:Restriction ;
     owl:hasValue tag:Lowest ;
+    owl:onProperty brick:hasTag .
+
+_:has_Luminaire a owl:Restriction ;
+    owl:hasValue tag:Luminaire ;
+    owl:onProperty brick:hasTag .
+
+_:has_Maintenance a owl:Restriction ;
+    owl:hasValue tag:Maintenance ;
     owl:onProperty brick:hasTag .
 
 _:has_Oil a owl:Restriction ;
@@ -8829,6 +10427,10 @@ _:has_Override a owl:Restriction ;
     owl:hasValue tag:Override ;
     owl:onProperty brick:hasTag .
 
+_:has_Peak a owl:Restriction ;
+    owl:hasValue tag:Peak ;
+    owl:onProperty brick:hasTag .
+
 _:has_Percent a owl:Restriction ;
     owl:hasValue tag:Percent ;
     owl:onProperty brick:hasTag .
@@ -8837,8 +10439,40 @@ _:has_Rain a owl:Restriction ;
     owl:hasValue tag:Rain ;
     owl:onProperty brick:hasTag .
 
+_:has_Reheat a owl:Restriction ;
+    owl:hasValue tag:Reheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Safety a owl:Restriction ;
+    owl:hasValue tag:Safety ;
+    owl:onProperty brick:hasTag .
+
+_:has_Space a owl:Restriction ;
+    owl:hasValue tag:Space ;
+    owl:onProperty brick:hasTag .
+
+_:has_Switch a owl:Restriction ;
+    owl:hasValue tag:Switch ;
+    owl:onProperty brick:hasTag .
+
+_:has_Today a owl:Restriction ;
+    owl:hasValue tag:Today ;
+    owl:onProperty brick:hasTag .
+
 _:has_Torque a owl:Restriction ;
     owl:hasValue tag:Torque ;
+    owl:onProperty brick:hasTag .
+
+_:has_Turn a owl:Restriction ;
+    owl:hasValue tag:Turn ;
+    owl:onProperty brick:hasTag .
+
+_:has_Ventilation a owl:Restriction ;
+    owl:hasValue tag:Ventilation ;
+    owl:onProperty brick:hasTag .
+
+_:has_Volume a owl:Restriction ;
+    owl:hasValue tag:Volume ;
     owl:onProperty brick:hasTag .
 
 _:has_Wind a owl:Restriction ;
@@ -8857,8 +10491,8 @@ _:has_Bypass a owl:Restriction ;
     owl:hasValue tag:Bypass ;
     owl:onProperty brick:hasTag .
 
-_:has_Coil a owl:Restriction ;
-    owl:hasValue tag:Coil ;
+_:has_Chiller a owl:Restriction ;
+    owl:hasValue tag:Chiller ;
     owl:onProperty brick:hasTag .
 
 _:has_Detected a owl:Restriction ;
@@ -8873,44 +10507,44 @@ _:has_Entering a owl:Restriction ;
     owl:hasValue tag:Entering ;
     owl:onProperty brick:hasTag .
 
+_:has_Frequency a owl:Restriction ;
+    owl:hasValue tag:Frequency ;
+    owl:onProperty brick:hasTag .
+
 _:has_Grains a owl:Restriction ;
     owl:hasValue tag:Grains ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lead a owl:Restriction ;
+    owl:hasValue tag:Lead ;
+    owl:onProperty brick:hasTag .
+
+_:has_Leak a owl:Restriction ;
+    owl:hasValue tag:Leak ;
     owl:onProperty brick:hasTag .
 
 _:has_Level a owl:Restriction ;
     owl:hasValue tag:Level ;
     owl:onProperty brick:hasTag .
 
-_:has_Mixed a owl:Restriction ;
-    owl:hasValue tag:Mixed ;
-    owl:onProperty brick:hasTag .
-
 _:has_Overridden a owl:Restriction ;
     owl:hasValue tag:Overridden ;
     owl:onProperty brick:hasTag .
 
-_:has_Pump a owl:Restriction ;
-    owl:hasValue tag:Pump ;
-    owl:onProperty brick:hasTag .
-
-_:has_Shutdown a owl:Restriction ;
-    owl:hasValue tag:Shutdown ;
+_:has_Panel a owl:Restriction ;
+    owl:hasValue tag:Panel ;
     owl:onProperty brick:hasTag .
 
 _:has_Smoke a owl:Restriction ;
     owl:hasValue tag:Smoke ;
     owl:onProperty brick:hasTag .
 
-_:has_Standby a owl:Restriction ;
-    owl:hasValue tag:Standby ;
-    owl:onProperty brick:hasTag .
-
 _:has_Tolerance a owl:Restriction ;
     owl:hasValue tag:Tolerance ;
     owl:onProperty brick:hasTag .
 
-_:has_Unit a owl:Restriction ;
-    owl:hasValue tag:Unit ;
+_:has_Variable a owl:Restriction ;
+    owl:hasValue tag:Variable ;
     owl:onProperty brick:hasTag .
 
 _:has_Average a owl:Restriction ;
@@ -8921,52 +10555,44 @@ _:has_Building a owl:Restriction ;
     owl:hasValue tag:Building ;
     owl:onProperty brick:hasTag .
 
-_:has_Cool a owl:Restriction ;
-    owl:hasValue tag:Cool ;
+_:has_Coil a owl:Restriction ;
+    owl:hasValue tag:Coil ;
+    owl:onProperty brick:hasTag .
+
+_:has_Condenser a owl:Restriction ;
+    owl:hasValue tag:Condenser ;
     owl:onProperty brick:hasTag .
 
 _:has_Dewpoint a owl:Restriction ;
     owl:hasValue tag:Dewpoint ;
     owl:onProperty brick:hasTag .
 
-_:has_Fault a owl:Restriction ;
-    owl:hasValue tag:Fault ;
-    owl:onProperty brick:hasTag .
-
-_:has_Filter a owl:Restriction ;
-    owl:hasValue tag:Filter ;
-    owl:onProperty brick:hasTag .
-
 _:has_Fixed a owl:Restriction ;
     owl:hasValue tag:Fixed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Interface a owl:Restriction ;
+    owl:hasValue tag:Interface ;
     owl:onProperty brick:hasTag .
 
 _:has_Leaving a owl:Restriction ;
     owl:hasValue tag:Leaving ;
     owl:onProperty brick:hasTag .
 
-_:has_Loss a owl:Restriction ;
-    owl:hasValue tag:Loss ;
-    owl:onProperty brick:hasTag .
-
 _:has_Luminance a owl:Restriction ;
     owl:hasValue tag:Luminance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Mixed a owl:Restriction ;
+    owl:hasValue tag:Mixed ;
     owl:onProperty brick:hasTag .
 
 _:has_Occupancy a owl:Restriction ;
     owl:hasValue tag:Occupancy ;
     owl:onProperty brick:hasTag .
 
-_:has_Output a owl:Restriction ;
-    owl:hasValue tag:Output ;
-    owl:onProperty brick:hasTag .
-
-_:has_Preheat a owl:Restriction ;
-    owl:hasValue tag:Preheat ;
-    owl:onProperty brick:hasTag .
-
-_:has_Reset a owl:Restriction ;
-    owl:hasValue tag:Reset ;
+_:has_Shutdown a owl:Restriction ;
+    owl:hasValue tag:Shutdown ;
     owl:onProperty brick:hasTag .
 
 _:has_Solar a owl:Restriction ;
@@ -8977,6 +10603,70 @@ _:has_Solid a owl:Restriction ;
     owl:hasValue tag:Solid ;
     owl:onProperty brick:hasTag .
 
+_:has_Storage a owl:Restriction ;
+    owl:hasValue tag:Storage ;
+    owl:onProperty brick:hasTag .
+
+_:has_VFD a owl:Restriction ;
+    owl:hasValue tag:VFD ;
+    owl:onProperty brick:hasTag .
+
+_:has_Voltage a owl:Restriction ;
+    owl:hasValue tag:Voltage ;
+    owl:onProperty brick:hasTag .
+
+_:has_Cool a owl:Restriction ;
+    owl:hasValue tag:Cool ;
+    owl:onProperty brick:hasTag .
+
+_:has_Direction a owl:Restriction ;
+    owl:hasValue tag:Direction ;
+    owl:onProperty brick:hasTag .
+
+_:has_Electrical a owl:Restriction ;
+    owl:hasValue tag:Electrical ;
+    owl:onProperty brick:hasTag .
+
+_:has_Exchanger a owl:Restriction ;
+    owl:hasValue tag:Exchanger ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fault a owl:Restriction ;
+    owl:hasValue tag:Fault ;
+    owl:onProperty brick:hasTag .
+
+_:has_Laboratory a owl:Restriction ;
+    owl:hasValue tag:Laboratory ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lockout a owl:Restriction ;
+    owl:hasValue tag:Lockout ;
+    owl:onProperty brick:hasTag .
+
+_:has_Loss a owl:Restriction ;
+    owl:hasValue tag:Loss ;
+    owl:onProperty brick:hasTag .
+
+_:has_Motor a owl:Restriction ;
+    owl:hasValue tag:Motor ;
+    owl:onProperty brick:hasTag .
+
+_:has_Output a owl:Restriction ;
+    owl:hasValue tag:Output ;
+    owl:onProperty brick:hasTag .
+
+_:has_Preheat a owl:Restriction ;
+    owl:hasValue tag:Preheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Stack a owl:Restriction ;
+    owl:hasValue tag:Stack ;
+    owl:onProperty brick:hasTag .
+
+_:has_Standby a owl:Restriction ;
+    owl:hasValue tag:Standby ;
+    owl:onProperty brick:hasTag .
+
 _:has_Start a owl:Restriction ;
     owl:hasValue tag:Start ;
     owl:onProperty brick:hasTag .
@@ -8985,40 +10675,20 @@ _:has_Stop a owl:Restriction ;
     owl:hasValue tag:Stop ;
     owl:onProperty brick:hasTag .
 
-_:has_Storage a owl:Restriction ;
-    owl:hasValue tag:Storage ;
+_:has_Velocity a owl:Restriction ;
+    owl:hasValue tag:Velocity ;
     owl:onProperty brick:hasTag .
 
-_:has_Voltage a owl:Restriction ;
-    owl:hasValue tag:Voltage ;
-    owl:onProperty brick:hasTag .
-
-_:has_Direction a owl:Restriction ;
-    owl:hasValue tag:Direction ;
+_:has_Box a owl:Restriction ;
+    owl:hasValue tag:Box ;
     owl:onProperty brick:hasTag .
 
 _:has_Energy a owl:Restriction ;
     owl:hasValue tag:Energy ;
     owl:onProperty brick:hasTag .
 
-_:has_Lockout a owl:Restriction ;
-    owl:hasValue tag:Lockout ;
-    owl:onProperty brick:hasTag .
-
-_:has_Motor a owl:Restriction ;
-    owl:hasValue tag:Motor ;
-    owl:onProperty brick:hasTag .
-
-_:has_Stack a owl:Restriction ;
-    owl:hasValue tag:Stack ;
-    owl:onProperty brick:hasTag .
-
-_:has_Velocity a owl:Restriction ;
-    owl:hasValue tag:Velocity ;
-    owl:onProperty brick:hasTag .
-
-_:has_Current a owl:Restriction ;
-    owl:hasValue tag:Current ;
+_:has_Fire a owl:Restriction ;
+    owl:hasValue tag:Fire ;
     owl:onProperty brick:hasTag .
 
 _:has_Gain a owl:Restriction ;
@@ -9029,20 +10699,28 @@ _:has_Run a owl:Restriction ;
     owl:hasValue tag:Run ;
     owl:onProperty brick:hasTag .
 
-_:has_Steam a owl:Restriction ;
-    owl:hasValue tag:Steam ;
+_:has_Unit a owl:Restriction ;
+    owl:hasValue tag:Unit ;
     owl:onProperty brick:hasTag .
 
-_:has_Disable a owl:Restriction ;
-    owl:hasValue tag:Disable ;
+_:has_Current a owl:Restriction ;
+    owl:hasValue tag:Current ;
     owl:onProperty brick:hasTag .
 
 _:has_Domestic a owl:Restriction ;
     owl:hasValue tag:Domestic ;
     owl:onProperty brick:hasTag .
 
+_:has_Filter a owl:Restriction ;
+    owl:hasValue tag:Filter ;
+    owl:onProperty brick:hasTag .
+
 _:has_Request a owl:Restriction ;
     owl:hasValue tag:Request ;
+    owl:onProperty brick:hasTag .
+
+_:has_Steam a owl:Restriction ;
+    owl:hasValue tag:Steam ;
     owl:onProperty brick:hasTag .
 
 _:has_Thermal a owl:Restriction ;
@@ -9053,28 +10731,24 @@ _:has_Usage a owl:Restriction ;
     owl:hasValue tag:Usage ;
     owl:onProperty brick:hasTag .
 
-_:has_Demand a owl:Restriction ;
-    owl:hasValue tag:Demand ;
-    owl:onProperty brick:hasTag .
-
-_:has_Emergency a owl:Restriction ;
-    owl:hasValue tag:Emergency ;
-    owl:onProperty brick:hasTag .
-
-_:has_Low a owl:Restriction ;
-    owl:hasValue tag:Low ;
+_:has_Disable a owl:Restriction ;
+    owl:hasValue tag:Disable ;
     owl:onProperty brick:hasTag .
 
 _:has_Meter a owl:Restriction ;
     owl:hasValue tag:Meter ;
     owl:onProperty brick:hasTag .
 
-_:has_System a owl:Restriction ;
-    owl:hasValue tag:System ;
+_:has_Pump a owl:Restriction ;
+    owl:hasValue tag:Pump ;
     owl:onProperty brick:hasTag .
 
 _:has_Damper a owl:Restriction ;
     owl:hasValue tag:Damper ;
+    owl:onProperty brick:hasTag .
+
+_:has_Demand a owl:Restriction ;
+    owl:hasValue tag:Demand ;
     owl:onProperty brick:hasTag .
 
 _:has_Enthalpy a owl:Restriction ;
@@ -9085,80 +10759,64 @@ _:has_Position a owl:Restriction ;
     owl:hasValue tag:Position ;
     owl:onProperty brick:hasTag .
 
-_:has_Heat a owl:Restriction ;
-    owl:hasValue tag:Heat ;
-    owl:onProperty brick:hasTag .
-
-_:has_High a owl:Restriction ;
-    owl:hasValue tag:High ;
-    owl:onProperty brick:hasTag .
-
-_:has_Mode a owl:Restriction ;
-    owl:hasValue tag:Mode ;
+_:has_Room a owl:Restriction ;
+    owl:hasValue tag:Room ;
     owl:onProperty brick:hasTag .
 
 _:has_Step a owl:Restriction ;
     owl:hasValue tag:Step ;
     owl:onProperty brick:hasTag .
 
-_:has_Shed a owl:Restriction ;
-    owl:hasValue tag:Shed ;
-    owl:onProperty brick:hasTag .
-
-_:has_Zone a owl:Restriction ;
-    owl:hasValue tag:Zone ;
-    owl:onProperty brick:hasTag .
-
 _:has_CO2 a owl:Restriction ;
     owl:hasValue tag:CO2 ;
     owl:onProperty brick:hasTag .
 
-_:has_Location a owl:Restriction ;
-    owl:hasValue tag:Location ;
+_:has_Emergency a owl:Restriction ;
+    owl:hasValue tag:Emergency ;
     owl:onProperty brick:hasTag .
 
-_:has_Unoccupied a owl:Restriction ;
-    owl:hasValue tag:Unoccupied ;
+_:has_Medium a owl:Restriction ;
+    owl:hasValue tag:Medium ;
     owl:onProperty brick:hasTag .
 
 _:has_Valve a owl:Restriction ;
     owl:hasValue tag:Valve ;
     owl:onProperty brick:hasTag .
 
-_:has_On a owl:Restriction ;
-    owl:hasValue tag:On ;
+_:has_Mode a owl:Restriction ;
+    owl:hasValue tag:Mode ;
     owl:onProperty brick:hasTag .
 
-_:has_Power a owl:Restriction ;
-    owl:hasValue tag:Power ;
-    owl:onProperty brick:hasTag .
-
-_:has_Off a owl:Restriction ;
-    owl:hasValue tag:Off ;
-    owl:onProperty brick:hasTag .
-
-_:has_Speed a owl:Restriction ;
-    owl:hasValue tag:Speed ;
-    owl:onProperty brick:hasTag .
-
-_:has_Fan a owl:Restriction ;
-    owl:hasValue tag:Fan ;
+_:has_System a owl:Restriction ;
+    owl:hasValue tag:System ;
     owl:onProperty brick:hasTag .
 
 _:has_Gas a owl:Restriction ;
     owl:hasValue tag:Gas ;
     owl:onProperty brick:hasTag .
 
-_:has_Load a owl:Restriction ;
-    owl:hasValue tag:Load ;
+_:has_Heat a owl:Restriction ;
+    owl:hasValue tag:Heat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Speed a owl:Restriction ;
+    owl:hasValue tag:Speed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Unoccupied a owl:Restriction ;
+    owl:hasValue tag:Unoccupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Zone a owl:Restriction ;
+    owl:hasValue tag:Zone ;
     owl:onProperty brick:hasTag .
 
 _:has_Humidity a owl:Restriction ;
     owl:hasValue tag:Humidity ;
     owl:onProperty brick:hasTag .
 
-_:has_Enable a owl:Restriction ;
-    owl:hasValue tag:Enable ;
+_:has_Low a owl:Restriction ;
+    owl:hasValue tag:Low ;
     owl:onProperty brick:hasTag .
 
 _:has_Occupied a owl:Restriction ;
@@ -9169,28 +10827,48 @@ _:has_Integral a owl:Restriction ;
     owl:hasValue tag:Integral ;
     owl:onProperty brick:hasTag .
 
+_:has_Location a owl:Restriction ;
+    owl:hasValue tag:Location ;
+    owl:onProperty brick:hasTag .
+
+_:has_On a owl:Restriction ;
+    owl:hasValue tag:On ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fan a owl:Restriction ;
+    owl:hasValue tag:Fan ;
+    owl:onProperty brick:hasTag .
+
 _:has_Band a owl:Restriction ;
     owl:hasValue tag:Band ;
     owl:onProperty brick:hasTag .
 
-_:has_Return a owl:Restriction ;
-    owl:hasValue tag:Return ;
+_:has_Enable a owl:Restriction ;
+    owl:hasValue tag:Enable ;
     owl:onProperty brick:hasTag .
 
-_:has_Exhaust a owl:Restriction ;
-    owl:hasValue tag:Exhaust ;
+_:has_High a owl:Restriction ;
+    owl:hasValue tag:High ;
+    owl:onProperty brick:hasTag .
+
+_:has_Power a owl:Restriction ;
+    owl:hasValue tag:Power ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shed a owl:Restriction ;
+    owl:hasValue tag:Shed ;
     owl:onProperty brick:hasTag .
 
 _:has_Liquid a owl:Restriction ;
     owl:hasValue tag:Liquid ;
     owl:onProperty brick:hasTag .
 
-_:has_Outside a owl:Restriction ;
-    owl:hasValue tag:Outside ;
-    owl:onProperty brick:hasTag .
-
 _:has_Proportional a owl:Restriction ;
     owl:hasValue tag:Proportional ;
+    owl:onProperty brick:hasTag .
+
+_:has_Return a owl:Restriction ;
+    owl:hasValue tag:Return ;
     owl:onProperty brick:hasTag .
 
 _:has_Time a owl:Restriction ;
@@ -9201,8 +10879,24 @@ _:has_Deadband a owl:Restriction ;
     owl:hasValue tag:Deadband ;
     owl:onProperty brick:hasTag .
 
+_:has_Exhaust a owl:Restriction ;
+    owl:hasValue tag:Exhaust ;
+    owl:onProperty brick:hasTag .
+
+_:has_Off a owl:Restriction ;
+    owl:hasValue tag:Off ;
+    owl:onProperty brick:hasTag .
+
+_:has_Load a owl:Restriction ;
+    owl:hasValue tag:Load ;
+    owl:onProperty brick:hasTag .
+
 _:has_Min a owl:Restriction ;
     owl:hasValue tag:Min ;
+    owl:onProperty brick:hasTag .
+
+_:has_Outside a owl:Restriction ;
+    owl:hasValue tag:Outside ;
     owl:onProperty brick:hasTag .
 
 _:has_Chilled a owl:Restriction ;
@@ -9213,76 +10907,80 @@ _:has_Max a owl:Restriction ;
     owl:hasValue tag:Max ;
     owl:onProperty brick:hasTag .
 
-_:has_Hot a owl:Restriction ;
-    owl:hasValue tag:Hot ;
+_:has_Reset a owl:Restriction ;
+    owl:hasValue tag:Reset ;
     owl:onProperty brick:hasTag .
 
 _:has_Cooling a owl:Restriction ;
     owl:hasValue tag:Cooling ;
     owl:onProperty brick:hasTag .
 
-_:has_Heating a owl:Restriction ;
-    owl:hasValue tag:Heating ;
-    owl:onProperty brick:hasTag .
-
 _:has_Fluid a owl:Restriction ;
     owl:hasValue tag:Fluid ;
+    owl:onProperty brick:hasTag .
+
+_:has_Heating a owl:Restriction ;
+    owl:hasValue tag:Heating ;
     owl:onProperty brick:hasTag .
 
 _:has_Static a owl:Restriction ;
     owl:hasValue tag:Static ;
     owl:onProperty brick:hasTag .
 
-_:has_Command a owl:Restriction ;
-    owl:hasValue tag:Command ;
-    owl:onProperty brick:hasTag .
-
 _:has_PID a owl:Restriction ;
     owl:hasValue tag:PID ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hot a owl:Restriction ;
+    owl:hasValue tag:Hot ;
     owl:onProperty brick:hasTag .
 
 _:has_Alarm a owl:Restriction ;
     owl:hasValue tag:Alarm ;
     owl:onProperty brick:hasTag .
 
-_:has_Equipment a owl:Restriction ;
-    owl:hasValue tag:Equipment ;
+_:has_Limit a owl:Restriction ;
+    owl:hasValue tag:Limit ;
+    owl:onProperty brick:hasTag .
+
+_:has_Command a owl:Restriction ;
+    owl:hasValue tag:Command ;
     owl:onProperty brick:hasTag .
 
 _:has_Differential a owl:Restriction ;
     owl:hasValue tag:Differential ;
     owl:onProperty brick:hasTag .
 
-_:has_Limit a owl:Restriction ;
-    owl:hasValue tag:Limit ;
+_:has_Status a owl:Restriction ;
+    owl:hasValue tag:Status ;
     owl:onProperty brick:hasTag .
 
 _:has_Discharge a owl:Restriction ;
     owl:hasValue tag:Discharge ;
     owl:onProperty brick:hasTag .
 
-_:has_Status a owl:Restriction ;
-    owl:hasValue tag:Status ;
+_:has_Flow a owl:Restriction ;
+    owl:hasValue tag:Flow ;
     owl:onProperty brick:hasTag .
 
 _:has_Supply a owl:Restriction ;
     owl:hasValue tag:Supply ;
     owl:onProperty brick:hasTag .
 
-_:has_Flow a owl:Restriction ;
-    owl:hasValue tag:Flow ;
-    owl:onProperty brick:hasTag .
-
 _:has_Pressure a owl:Restriction ;
     owl:hasValue tag:Pressure ;
     owl:onProperty brick:hasTag .
 
-_:has_Water a owl:Restriction ;
-    owl:hasValue tag:Water ;
+_:has_Equipment a owl:Restriction ;
+    owl:hasValue tag:Equipment ;
     owl:onProperty brick:hasTag .
 
 _:has_Parameter a owl:Restriction ;
     owl:hasValue tag:Parameter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Water a owl:Restriction ;
+    owl:hasValue tag:Water ;
     owl:onProperty brick:hasTag .
 
 _:has_Temperature a owl:Restriction ;
@@ -9299,5 +10997,9 @@ _:has_Setpoint a owl:Restriction ;
 
 _:has_Air a owl:Restriction ;
     owl:hasValue tag:Air ;
+    owl:onProperty brick:hasTag .
+
+_:has_Point a owl:Restriction ;
+    owl:hasValue tag:Point ;
     owl:onProperty brick:hasTag .
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -299,6 +299,14 @@ requests = "*"
 
 [[package]]
 category = "main"
+description = "An OWL 2 RL reasoner with reasonable performance"
+name = "reasonable"
+optional = false
+python-versions = "*"
+version = "0.1.4"
+
+[[package]]
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -403,7 +411,7 @@ python-versions = ">=3.6"
 version = "2.1.0"
 
 [metadata]
-content-hash = "79c4644442554210ea5a74b5ba9c02941602d717da340ef4340e67764e31a6d1"
+content-hash = "d3f581c673cb73013e30cff1b03e07849a778a4b8896d321462e82f12f0055d3"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -436,6 +444,7 @@ pywin32 = ["300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be", "
 rdflib = ["58d5994610105a457cff7fdfe3d683d87786c5028a45ae032982498a7e913d6f", "da1df14552555c5c7715d8ce71c08f404c988c58a1ecd38552d0da4fc261280d"]
 rdflib-jsonld = ["144774786a2fc7de09b24a9309cbcccc78bc48b152536d2ea1c1df2ad715bc2d"]
 readthedocs-sphinx-ext = ["52501523f05fdbe8342bce816b4d19760d799cbf6e9c221a91c11caa8da387cb", "c920d8129752ee3f339c8cf3dfeba800a25730249d6ab43dc9b3c384312d1d32"]
+reasonable = ["cdb808c7673ad63c20e474a34c09bc84fa8ec95160896fccd85ef2b59ce28bd2"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
 six = ["1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd", "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"]
 snowballstemmer = ["209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0", "df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,7 +65,7 @@ description = "A Python library for the Docker Engine API."
 name = "docker"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.1.0"
+version = "4.2.0"
 
 [package.dependencies]
 requests = ">=2.14.2,<2.18.0 || >2.18.0"
@@ -107,7 +107,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.4.0"
+version = "1.5.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -128,8 +128,8 @@ category = "dev"
 description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
-python-versions = "*"
-version = "2.10.3"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.1"
 
 [package.dependencies]
 MarkupSafe = ">=0.23"
@@ -148,7 +148,7 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.1.0"
+version = "8.2.0"
 
 [[package]]
 category = "main"
@@ -209,7 +209,7 @@ description = "Python parsing module"
 name = "pyparsing"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.5"
+version = "2.4.6"
 
 [[package]]
 category = "main"
@@ -229,7 +229,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.3.4"
+version = "5.3.5"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -301,9 +301,9 @@ requests = "*"
 category = "main"
 description = "An OWL 2 RL reasoner with reasonable performance"
 name = "reasonable"
-optional = false
+optional = true
 python-versions = "*"
-version = "0.1.4"
+version = "0.1.6"
 
 [[package]]
 category = "main"
@@ -324,8 +324,8 @@ category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.13.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.14.0"
 
 [[package]]
 category = "dev"
@@ -363,8 +363,8 @@ category = "dev"
 description = "Sphinx API for Web Apps"
 name = "sphinxcontrib-websupport"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.1.2"
+python-versions = ">=3.5"
+version = "1.2.0"
 
 [[package]]
 category = "main"
@@ -408,10 +408,13 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "2.1.0"
+version = "2.2.0"
+
+[extras]
+reasonable = ["reasonable"]
 
 [metadata]
-content-hash = "d3f581c673cb73013e30cff1b03e07849a778a4b8896d321462e82f12f0055d3"
+content-hash = "f62b36321614395d10df9c1481dc6b266a9d8acfab4ad8b3b7f6ada2685a4212"
 python-versions = "^3.6"
 
 [metadata.hashes]
@@ -422,36 +425,36 @@ babel = ["1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38", "d6
 certifi = ["017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3", "25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"]
 chardet = ["84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae", "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"]
 colorama = ["7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff", "e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"]
-docker = ["6e06c5e70ba4fad73e35f00c55a895a448398f3ada7faae072e2bb01348bafc1", "8f93775b8bdae3a2df6bc9a5312cce564cade58d6555f2c2570165a1270cd8a7"]
+docker = ["1c2ddb7a047b2599d1faec00889561316c674f7099427b9c51e8cb804114b553", "ddae66620ab5f4bce769f64bcd7934f880c8abe6aa50986298db56735d0f722e"]
 docutils = ["0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af", "c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"]
 idna = ["c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407", "ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"]
 imagesize = ["6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1", "b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"]
-importlib-metadata = ["bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359", "f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"]
+importlib-metadata = ["06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302", "b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"]
 isodate = ["2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8", "aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"]
-jinja2 = ["74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f", "9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"]
+jinja2 = ["93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250", "b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"]
 markupsafe = ["00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473", "09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161", "09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235", "1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5", "24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff", "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b", "43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1", "46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e", "500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183", "535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66", "62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1", "6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1", "717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e", "79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b", "7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905", "88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735", "8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d", "98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e", "9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d", "9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c", "ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21", "b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2", "b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5", "b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b", "ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6", "c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f", "cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f", "e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"]
-more-itertools = ["1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39", "c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"]
+more-itertools = ["5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c", "b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"]
 owlrl = ["2ad753f5ba6d1fe2d88bf36f427df31553f2eaa0283692e3cd06cab20ac8aec3", "efdebe76cf9ad148f316a9ae92e898e12b3b3690bd90218c898a2b676955b266"]
 packaging = ["170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73", "e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"]
 pluggy = ["15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0", "966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"]
 py = ["5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa", "c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"]
 pygments = ["2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b", "98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"]
-pyparsing = ["20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f", "4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"]
+pyparsing = ["4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f", "c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"]
 pypiwin32 = ["67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775", "71be40c1fbd28594214ecaecb58e7aa8b708eabfa0125c8a109ebd51edbd776a"]
-pytest = ["1d122e8be54d1a709e56f82e2d85dcba3018313d64647f38a91aec88c239b600", "c13d1943c63e599b98cf118fcb9703e4d7bde7caa9a432567bcdcae4bf512d20"]
+pytest = ["0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d", "ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"]
 pytz = ["1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d", "b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"]
 pywin32 = ["300a2db938e98c3e7e2093e4491439e62287d0d493fe07cce110db070b54c0be", "31f88a89139cb2adc40f8f0e65ee56a8c585f629974f9e07622ba80199057511", "371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0", "47a3c7551376a865dd8d095a98deba954a98f326c6fe3c72d8726ca6e6b15507", "4cdad3e84191194ea6d0dd1b1b9bdda574ff563177d2adf2b4efec2a244fa116", "7c1ae32c489dc012930787f06244426f8356e129184a02c25aef163917ce158e", "7f18199fbf29ca99dff10e1f09451582ae9e372a892ff03a28528a24d55875bc", "9b31e009564fb95db160f154e2aa195ed66bcc4c058ed72850d047141b36f3a2", "a929a4af626e530383a579431b70e512e736e9588106715215bf685a3ea508d4", "c054c52ba46e7eb6b7d7dfae4dbd987a1bb48ee86debe3f245a2884ece46e295", "f27cec5e7f588c3d1051651830ecc00294f90728d19c3bf6916e6dba93ea357c", "f4c5be1a293bae0076d93c88f37ee8da68136744588bc5e2be2f299a34ceb7aa"]
 rdflib = ["58d5994610105a457cff7fdfe3d683d87786c5028a45ae032982498a7e913d6f", "da1df14552555c5c7715d8ce71c08f404c988c58a1ecd38552d0da4fc261280d"]
 rdflib-jsonld = ["144774786a2fc7de09b24a9309cbcccc78bc48b152536d2ea1c1df2ad715bc2d"]
 readthedocs-sphinx-ext = ["52501523f05fdbe8342bce816b4d19760d799cbf6e9c221a91c11caa8da387cb", "c920d8129752ee3f339c8cf3dfeba800a25730249d6ab43dc9b3c384312d1d32"]
-reasonable = ["cdb808c7673ad63c20e474a34c09bc84fa8ec95160896fccd85ef2b59ce28bd2"]
+reasonable = ["0f45884f9fa63a68d2626f9f6e3a939a83224b2c228827c7dd4286e8647ce202", "118aef75bc222c523b6b6866b2fe9aee9c92be2784230aed7ff2cd1d94bf14e1", "ea0f146d62b9f99f82828eda7b526778be55ec64279aa311c085f030be894a44"]
 requests = ["11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4", "9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"]
-six = ["1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd", "30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"]
+six = ["236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a", "8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"]
 snowballstemmer = ["209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0", "df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"]
 sphinx = ["9f3e17c64b34afc653d7c5ec95766e03043cc6d80b0de224f59b6b6e19d37c3c", "c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08"]
-sphinxcontrib-websupport = ["1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc", "e02f717baf02d0b6c3dd62cf81232ffca4c9d5c331e03766982e3ff9f1d2bc3f"]
+sphinxcontrib-websupport = ["50fb98fcb8ff2a8869af2afa6b8ee51b3baeb0b17dacd72505105bf15d506ead", "bad3fbd312bc36a31841e06e7617471587ef642bdacdbdddaa8cc30cf251b5ea"]
 sqlalchemy = ["64a7b71846db6423807e96820993fa12a03b89127d278290ca25c0b11ed7b4fb"]
 urllib3 = ["2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc", "87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"]
 wcwidth = ["8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603", "f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"]
 websocket-client = ["0fc45c961324d79c781bab301359d5a1b00b13ad1b10415a4780229ef71a5549", "d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"]
-zipp = ["ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28", "feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"]
+zipp = ["5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50", "d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ owlrl = "^5.2"
 sqlalchemy = "^1.3"
 docker = "^4.1"
 pytest = "^5.3"
-reasonable = { version = "^0.1.4", optional = true }
+reasonable = { version = "^0.1.6", optional = true }
 
 [tool.poetry.extras]
 reasonable = ["reasonable"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ owlrl = "^5.2"
 sqlalchemy = "^1.3"
 docker = "^4.1"
 pytest = "^5.3"
+reasonable = { version = "^0.1.4", optional = true }
+
+[tool.poetry.extras]
+reasonable = ["reasonable"]
 
 [tool.poetry.dev-dependencies]
 readthedocs-sphinx-ext = "^1.0"

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -213,8 +213,6 @@ def test_owl_inference_tags_reasonable():
     }}""")
 
     expected = [
-        RDF.Resource,
-        RDFS.Resource,
         OWL.Thing,
         BRICK.Point,
         BRICK.Class,
@@ -225,10 +223,7 @@ def test_owl_inference_tags_reasonable():
     # filter out BNodes
     res1 = filter_bnodes(res1)
 
-    assert len(res1) == len(expected), f"Results were {res1}"
-    for expected_class in expected:
-        assert (expected_class, ) in res1,\
-            f"{expected_class} not found in {res1}"
+    assert set(res1) == set(map(lambda x: (x, ), expected))
 
     res2 = expanded_graph.query(f"""SELECT ?tag WHERE {{
         <{EX["a"]}> brick:hasTag ?tag
@@ -242,10 +237,7 @@ def test_owl_inference_tags_reasonable():
     ]
     res2 = filter_bnodes(res2)
 
-    assert len(res2) == len(expected), f"Results were {res2}"
-    for expected_tag in expected:
-        assert (expected_tag, ) in res2,\
-            f"{expected_tag} not found in {res2}"
+    assert set(res2) == set(map(lambda x: (x, ), expected))
 
 
 def test_inverse_edge_inference():


### PR DESCRIPTION
Provides an interface to the OWL-RL reasoner implemented at https://github.com/gtfierro/reasonable

Basic usage looks like:

```python
from brickschema.inference import OWLRLReasonableInferenceSession
from brickschema.graph import Graph

g = Graph()
g.load_file('input.ttl')

session = OWLRLReasonableInferenceSession()
session.expand(g)
```