### PR TITLE
Add and document install flags for optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,21 @@ The `brickschema` package requires Python >= 3.6. It can be installed with `pip`
 pip install brickschema
 ```
 
+The `brickschema` package offers several installation configuration options for reasoning.
+The default bundled [OWLRL](https://pypi.org/project/owlrl/) reasoner delivers correct results, but exhibits poor performance on large or complex ontologies (we have observed minutes to hours) due to its bruteforce implementation.
+
+The [Allegro reasoner](https://franz.com/agraph/support/documentation/current/materializer.html) has better performance and implements enough of the OWLRL profile to be useful. We execute Allegrograph in a Docker container, which requires the `docker` package. To install support for the Allegrograph reasoner, use
+
+```
+pip install brickschema[allegro]
+```
+
+The [reasonable Reasoner](https://github.com/gtfierro/reasonable) offers even better performance than the Allegro reasoner, but is currently only packaged for Linux platforms. (_Note: no fundamental limitations here, just some packaging complexity due to cross-compiling the `.so`_). To install support for the reasonable Reasoner, use
+
+```
+pip install brickschema[reasonable]
+```
+
 ## Haystack Inference
 
 Requires a JSON export of a Haystack model

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -101,7 +101,13 @@ class OWLRLReasonableInferenceSession:
         Args:
             load_brick (bool): if True, load Brick ontology into the graph
         """
-        from reasonable import PyReasoner
+        try:
+            from reasonable import PyReasoner
+        except ImportError as e:
+            print(f"'reasonable' package not found. Install support for the\
+reasonable Reasoner with 'pip install \
+brickschema[reasonable]. Currently only works on Linux")
+            raise e
         self.r = PyReasoner()
         self.g = Graph(load_brick=load_brick)
 
@@ -164,7 +170,8 @@ class OWLRLAllegroInferenceSession:
             import docker
         except ImportError as e:
             print(f"'docker' package not found. Install support for Allegro\
-                   with 'pip install brickschema[allegro] {e}")
+                   with 'pip install brickschema[allegro]")
+            raise e
 
         self.g = Graph(load_brick=load_brick)
 

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -103,11 +103,10 @@ class OWLRLReasonableInferenceSession:
         """
         try:
             from reasonable import PyReasoner
-        except ImportError as e:
-            print(f"'reasonable' package not found. Install support for the\
-reasonable Reasoner with 'pip install \
-brickschema[reasonable]. Currently only works on Linux")
-            raise e
+        except ImportError:
+            raise ImportError(f"'reasonable' package not found. Install\
+support for the reasonable Reasoner with 'pip install brickschema[reasonable].\
+Currently only works on Linux")
         self.r = PyReasoner()
         self.g = Graph(load_brick=load_brick)
 
@@ -168,10 +167,9 @@ class OWLRLAllegroInferenceSession:
 
         try:
             import docker
-        except ImportError as e:
-            print(f"'docker' package not found. Install support for Allegro\
-                   with 'pip install brickschema[allegro]")
-            raise e
+        except ImportError:
+            raise ImportError(f"'docker' package not found. Install support \
+for Allegro with 'pip install brickschema[allegro]")
 
         self.g = Graph(load_brick=load_brick)
 

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -12,7 +12,6 @@ import rdflib
 import owlrl
 import io
 import tarfile
-import docker
 
 
 class RDFSInferenceSession:
@@ -133,7 +132,7 @@ class OWLRLReasonableInferenceSession:
                 return rdflib.URIRef(s)
             else:
                 return rdflib.BNode(s)
-        except:
+        except Exception:
             return rdflib.Literal(s)
 
     @property
@@ -151,11 +150,22 @@ class OWLRLAllegroInferenceSession:
 
     def __init__(self, load_brick=True):
         """
-        Creates a new OWLRL Inference session
+        Creates a new OWLRL Inference session backed by the Allegrograph
+        reasoner (https://franz.com/agraph/support/documentation/current/materializer.html).
+        Requires the docker package to work; recommended method of installing
+        is to use the 'allegro' option with pip:
+            pip install brickschema[allegro]
 
         Args:
             load_brick (bool): if True, load Brick ontology into the graph
         """
+
+        try:
+            import docker
+        except ImportError as e:
+            print(f"'docker' package not found. Install support for Allegro\
+                   with 'pip install brickschema[allegro] {e}")
+
         self.g = Graph(load_brick=load_brick)
 
         self._client = docker.from_env()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brickschema"
-version = "0.1.0"
+version = "0.1.1-a1"
 description = "A library for working with the Brick ontology for buildings (brickschema.org)"
 readme = "README.md"
 authors = ["Gabe Fierro <gtfierro@cs.berkeley.edu>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,13 @@ python = "^3.6"
 rdflib = "^4.2"
 owlrl = "^5.2"
 sqlalchemy = "^1.3"
-docker = "^4.1"
 pytest = "^5.3"
+docker = { version = "^4.1", optional = true }
 reasonable = { version = "^0.1.6", optional = true }
 
 [tool.poetry.extras]
 reasonable = ["reasonable"]
+allegro = ["docker"]
 
 [tool.poetry.dev-dependencies]
 readthedocs-sphinx-ext = "^1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brickschema"
-version = "0.1.1-a1"
+version = "0.1.1-a2"
 description = "A library for working with the Brick ontology for buildings (brickschema.org)"
 readme = "README.md"
 authors = ["Gabe Fierro <gtfierro@cs.berkeley.edu>"]


### PR DESCRIPTION
Introduces both the `allegro` and `reasonable` options for supporting those reasoners. Changes are available in v0.1.1-a1 on pypi. Documents the options in the README as well.

The `reasonable` and `docker` dependencies are now both optional with this fix