### PR TITLE
Implement fallthrough interface for OWLRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,33 @@ The [reasonable Reasoner](https://github.com/gtfierro/reasonable) offers even be
 pip install brickschema[reasonable]
 ```
 
+## OWLRL Inference
+
+`brickschema` makes it easier to employ OWLRL reasoning on your graphs. The package will automatically use the fastest available reasoning implementation for your system:
+
+- `reasonable` (fastest, Linux-only for now): `pip install brickschema[reasonable]`
+- `Allegro` (next-fastest, requires Docker): `pip install brickschema[allegro]`
+- OWLRL (default, native Python implementation): `pip install brickschema`
+
+To use OWL inference, import the `OWLRLInferenceSession` class (this automatically chooses the fastest reasoner; check out the [inference module documentation](https://brickschema.readthedocs.io/en/latest/source/brickschema.html#module-brickschema.inference) for how to use a specific reasoner). Create a `brickschema.Graph` with your ontology rules and instances loaded in and apply the reasoner's session to it:
+
+```python
+from brickschema.graph import Graph
+from brickschema.namespaces import BRICK
+from brickschema.inference import OWLRLInferenceSession
+
+g = Graph(load_brick=True)
+g.load_file("test.ttl")
+
+sess = OWLRLInferenceSession()
+inferred_graph = sess.expand(g)
+print(f"Inferred graph has {len(inferred_graph)} triples")
+```
+
+
 ## Haystack Inference
 
-Requires a JSON export of a Haystack model
+Requires a JSON export of a Haystack model.
 First, export your Haystack model as JSON; we are using the public reference model `carytown.json`.
 Then you can use this package as follows:
 

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -2,6 +2,7 @@
 The `inference` module implements inference of Brick entities from tags
 and other representations of building metadata
 """
+import logging
 import pkgutil
 import pickle
 from collections import defaultdict
@@ -12,6 +13,10 @@ import rdflib
 import owlrl
 import io
 import tarfile
+
+
+logging.basicConfig(format='%(asctime)s,%(msecs)d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+                    datefmt='%Y-%m-%d:%H:%M:%S', level=logging.INFO)
 
 
 class RDFSInferenceSession:
@@ -52,6 +57,50 @@ class RDFSInferenceSession:
 
 
 class OWLRLInferenceSession:
+    """
+    Common entrypoint to OWL inference that automatically chooses the fastest
+    available inference implementation. The priorities are as follows:
+
+    1. reasonable (Linux only for now): pip install brickschema[reasonable]
+    2. Allegro (requires docker): pip install brickschema[allegro]
+    3. OWLRL Python package (can be slow)
+    """
+    def __init__(self, load_brick=True):
+        """
+        Creates a new OWLRL Inference session
+
+        Args:
+            load_brick (bool): if True, load Brick ontology into the graph
+        """
+        try:
+            self.sess = OWLRLReasonableInferenceSession(load_brick=load_brick)
+        except ImportError:
+            logging.warning("Reasonable not installed; trying Allegro")
+            try:
+                logging.warning("Allegro not installed; defaulting to OWLRL")
+                self.sess = OWLRLAllegroInferenceSession(load_brick=load_brick)
+            except ImportError:
+                self.sess = OWLRLNaiveInferenceSession(load_brick=load_brick)
+
+    def expand(self, graph):
+        """
+        Applies OWLRL reasoning from the Python owlrl library to the graph
+
+        Args:
+            graph (brickschema.graph.Graph): a Graph object containing triples
+
+        Returns:
+            graph (brickschema.graph.Graph): a Graph object containing the
+                inferred triples in addition to the regular graph
+        """
+        return self.sess.expand(graph)
+
+    @property
+    def triples(self):
+        return self.sess.g.triples
+
+
+class OWLRLNaiveInferenceSession:
     """
     Provides methods and an inferface for producing the deductive closure
     of a graph under OWL-RL semantics. WARNING this may take a long time

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -77,9 +77,9 @@ class OWLRLInferenceSession:
         except ImportError:
             logging.warning("Reasonable not installed; trying Allegro")
             try:
-                logging.warning("Allegro not installed; defaulting to OWLRL")
                 self.sess = OWLRLAllegroInferenceSession(load_brick=load_brick)
             except ImportError:
+                logging.warning("Allegro not installed; defaulting to OWLRL")
                 self.sess = OWLRLNaiveInferenceSession(load_brick=load_brick)
 
     def expand(self, graph):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "brickschema"
-version = "0.1.1-a2"
+version = "0.1.2-a1"
 description = "A library for working with the Brick ontology for buildings (brickschema.org)"
 readme = "README.md"
 authors = ["Gabe Fierro <gtfierro@cs.berkeley.edu>"]


### PR DESCRIPTION
Automatically choose the fastest option available:

- logic implemented behind `brickschema.inference.OWLRLInferenceSession`
- documented in README