### PR TITLE
Fix docs build

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,7 @@ Run tests to make sure build is not broken
 # from within the environment; e.g. after running 'poetry shell'
 make test
 ```
+
+### Docs
+
+Docs are written in reStructured Text. Make sure that you add your package requirements to `docs/requirements.txt`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@ owlrl
 sqlalchemy
 pytest
 docker
+pyshacl
 Sphinx==2.3.1
 readthedocs-sphinx-ext


### PR DESCRIPTION
Fixes the documentation build by bringing the `pyshacl` package into the readthedocs folder `requirements.txt`