### PR TITLE
Update README.md poetry install line in 'Development' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,7 @@ Brick requires Python >= 3.6. We use [pre-commit hooks](https://pre-commit.com/)
 Use [Poetry](https://python-poetry.org/docs/) to manage packaging and dependencies. After installing poetry, install dependencies with:
 
 ```bash
-# -D flag installs development dependencies
-poetry install -D
+poetry install
 ```
 
 Enter the development environment with the following command (this is analogous to activating a virtual environment.


### PR DESCRIPTION
Just ran through setting this up - poetry install -D is not a valid command anymore it seems. 

I have updated poetry install dependencies line. Option -D is not valid, according to the poetry docs it appears dev dependencies are installed by default.