### PR TITLE
Fix default inference session selection

### DIFF
--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -237,6 +237,7 @@ source to load_file"
                     self._inferbackend = OWLRLReasonableInferenceSession()
                     backend = "reasonable"
             except ImportError:
+                print("Could not load Reasonable reasoner")
                 self._inferbackend = OWLRLNaiveInferenceSession()
 
             try:
@@ -244,6 +245,7 @@ source to load_file"
                     self._inferbackend = OWLRLAllegroInferenceSession()
                     backend = "allegrograph"
             except (ImportError, ConnectionError):
+                print("Could not load Allegro reasoner")
                 self._inferbackend = OWLRLNaiveInferenceSession()
         elif profile == "vbis":
             self._inferbackend = VBISTagInferenceSession(

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -11,6 +11,7 @@ import pkgutil
 import rdflib
 import owlrl
 import pyshacl
+import logging
 from .inference import (
     OWLRLNaiveInferenceSession,
     OWLRLReasonableInferenceSession,
@@ -21,6 +22,9 @@ from .inference import (
 )
 from . import namespaces as ns
 from . import web
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class Graph(rdflib.Graph):
@@ -237,7 +241,7 @@ source to load_file"
                     self._inferbackend = OWLRLReasonableInferenceSession()
                     backend = "reasonable"
             except ImportError:
-                print("Could not load Reasonable reasoner")
+                logger.info("Could not load Reasonable reasoner")
                 self._inferbackend = OWLRLNaiveInferenceSession()
 
             try:
@@ -245,7 +249,7 @@ source to load_file"
                     self._inferbackend = OWLRLAllegroInferenceSession()
                     backend = "allegrograph"
             except (ImportError, ConnectionError):
-                print("Could not load Allegro reasoner")
+                logger.info("Could not load Allegro reasoner")
                 self._inferbackend = OWLRLNaiveInferenceSession()
         elif profile == "vbis":
             self._inferbackend = VBISTagInferenceSession(

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -243,7 +243,7 @@ source to load_file"
                 if backend is None or backend == "allegrograph":
                     self._inferbackend = OWLRLAllegroInferenceSession()
                     backend = "allegrograph"
-            except ImportError:
+            except (ImportError, ConnectionError):
                 self._inferbackend = OWLRLNaiveInferenceSession()
         elif profile == "vbis":
             self._inferbackend = VBISTagInferenceSession(

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -93,6 +93,8 @@ for Allegro with 'pip install brickschema[allegro]"
             logging.error(
                 f"Could not connect to docker ({e}); defaulting to naive evaluation"
             )
+            raise ConnectionError(e)
+
         containers = self._client.containers.list(all=True)
         print(f"Checking {len(containers)} containers")
         for c in containers:


### PR DESCRIPTION
When trying to set up a development environment for BrickSchema/Brick I was getting error messages relating to 'docker connection' when trying to run 'make test'. Problem seems to stem from the default inference session selection in this dependency.

I think the error was introduced in the March 4 commit #44 . To fix I have updated the OWLRLAllegroInferenceSession to raise a `ConnectionError` if it fails to connect to a docker instance, and updated the graph expand method to fallback to naive inference on receipt, as it already does for the `ImportError`.

These changes seem to fix the development environment setup issues I was having for BrickSchema/Brick.

I've attached the original errors below for reference (from BrickSchema/Brick: 'make test')
```
(Brick-CGBt5J5p) wcrd@SA1035:~/programming/forked/Brick$ make test
mkdir -p extensions
python generate_brick.py
2021-04-06:14:01:43,302 ERROR   [inference.py:93] Could not connect to docker (Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))); defaulting to naive evaluation
Traceback (most recent call last):
  File "generate_brick.py", line 41, in <module>
    from bricksrc.quantities import quantity_definitions, get_units
  File "/home/wcrd/programming/forked/Brick/bricksrc/quantities.py", line 11, in <module>
    g.expand(profile="brick")
  File "/home/wcrd/.local/share/virtualenvs/Brick-CGBt5J5p/lib/python3.8/site-packages/brickschema/graph.py", line 226, in expand
    return self.expand("owlrl+shacl+owlrl", backend=backend)
  File "/home/wcrd/.local/share/virtualenvs/Brick-CGBt5J5p/lib/python3.8/site-packages/brickschema/graph.py", line 222, in expand
    self.expand(prf, backend=backend)
  File "/home/wcrd/.local/share/virtualenvs/Brick-CGBt5J5p/lib/python3.8/site-packages/brickschema/graph.py", line 244, in expand
    self._inferbackend = OWLRLAllegroInferenceSession()
  File "/home/wcrd/.local/share/virtualenvs/Brick-CGBt5J5p/lib/python3.8/site-packages/brickschema/inference.py", line 96, in __init__
    containers = self._client.containers.list(all=True)
AttributeError: 'OWLRLAllegroInferenceSession' object has no attribute '_client'
make: *** [Makefile:5: Brick.ttl] Error 1
```