### PR TITLE
Automatically add namespace bindings from the graph to Yasqe

### DIFF
--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -416,12 +416,12 @@ source to load_file"
             allow_warnings=True,
         )
 
-    def serve(self, address="127.0.0.1:8080"):
+    def serve(self, address="127.0.0.1:8080", ignore_prefixes = []):
         """
         Start web server offering SPARQL queries and 1-click reasoning capabilities
 
         Args:
           address (str): <host>:<port> of the web server
         """
-        srv = web.Server(self)
+        srv = web.Server(self, ignore_prefixes)
         srv.start(address)

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -416,12 +416,12 @@ source to load_file"
             allow_warnings=True,
         )
 
-    def serve(self, address="127.0.0.1:8080", ignore_prefixes = []):
+    def serve(self, address="127.0.0.1:8080", ignore_prefixes=[]):
         """
         Start web server offering SPARQL queries and 1-click reasoning capabilities
 
         Args:
           address (str): <host>:<port> of the web server
         """
-        srv = web.Server(self, ignore_prefixes)
+        srv = web.Server(self, ignore_prefixes=ignore_prefixes)
         srv.start(address)

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -422,6 +422,7 @@ source to load_file"
 
         Args:
           address (str): <host>:<port> of the web server
+          ignore_prefixes (list[str]): list of prefixes not to be added to the query editor's namespace bindings.
         """
         srv = web.Server(self, ignore_prefixes=ignore_prefixes)
         srv.start(address)

--- a/brickschema/web.py
+++ b/brickschema/web.py
@@ -13,8 +13,9 @@ import io
 
 
 class Server:
-    def __init__(self, graph):
+    def __init__(self, graph, ignore_prefixes=[]):
         self.graph = graph
+        self.ignore_prefixes = ignore_prefixes
         self.app = Flask(__name__, static_url_path="/static")
 
         self.app.route("/query", methods=["GET", "POST"])(self.query)
@@ -46,9 +47,8 @@ class Server:
         return pkgutil.get_data(__name__, "web/index.html").decode()
 
     def bindings(self):
-        ignored_prefixes = []
         return jsonify(
-            {prefix: namespace for prefix, namespace in self.graph.namespaces() if prefix not in ignored_prefixes})
+            {prefix: namespace for prefix, namespace in self.graph.namespaces() if prefix not in self.ignore_prefixes})
 
     def apply_reasoning(self, profile):
         self.graph.expand(profile)

--- a/brickschema/web.py
+++ b/brickschema/web.py
@@ -46,7 +46,9 @@ class Server:
         return pkgutil.get_data(__name__, "web/index.html").decode()
 
     def bindings(self):
-        return jsonify({prefix: namespace for prefix, namespace in self.graph.namespaces()})
+        ignored_prefixes = []
+        return jsonify(
+            {prefix: namespace for prefix, namespace in self.graph.namespaces() if prefix not in ignored_prefixes})
 
     def apply_reasoning(self, profile):
         self.graph.expand(profile)

--- a/brickschema/web.py
+++ b/brickschema/web.py
@@ -20,6 +20,7 @@ class Server:
         self.app.route("/query", methods=["GET", "POST"])(self.query)
         self.app.route("/reason/<profile>", methods=["POST"])(self.apply_reasoning)
         self.app.route("/", methods=["GET"])(self.home)
+        self.app.route("/bindings", methods=["GET"])(self.bindings)
 
     def query(self):
         if request.method == "GET":
@@ -43,6 +44,9 @@ class Server:
 
     def home(self):
         return pkgutil.get_data(__name__, "web/index.html").decode()
+
+    def bindings(self):
+        return jsonify({prefix: namespace for prefix, namespace in self.graph.namespaces()})
 
     def apply_reasoning(self, profile):
         self.graph.expand(profile)

--- a/brickschema/web/index.html
+++ b/brickschema/web/index.html
@@ -37,7 +37,14 @@
             keys: [],
         }
     });
-    y.getTab().yasqe.addPrefixes({
+    fetch("/bindings")
+    .then(res => res.json())
+    .then((bindings) => {
+        // add namespace bindings from the graph
+        y.getTab().yasqe.addPrefixes(bindings);
+    }).catch(err => {
+        // fallback
+        y.getTab().yasqe.addPrefixes({
             "brick": "https://brickschema.org/schema/Brick#",
             "owl": "http://www.w3.org/2002/07/owl#",
             "sh": "http://www.w3.org/ns/shacl#",
@@ -47,6 +54,7 @@
             "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
             "unit": "http://qudt.org/vocab/unit/",
         });
+    });
 
 </script>
 </body>


### PR DESCRIPTION
Especially useful when users are working on graphs with several bindings. Feel free to add some prefixes `:string` to the `ignored_prefixes` list. 