### PR TITLE
Optional features

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -34,7 +34,7 @@ jobs:
                 key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
             - name: Install dependencies
               if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-              run: poetry install --no-interaction --no-root
+              run: poetry install --no-interaction --no-root -E all
             - name: Install Dependencies
               run: |
                   poetry install --no-interaction

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/brickschema/__init__.py
+++ b/brickschema/__init__.py
@@ -6,7 +6,7 @@ for working with, developing and interacting with Brick models.
 import logging
 from .graph import Graph, GraphCollection
 from .namespaces import bind_prefixes
-from . import inference, namespaces, validate, web
+from . import inference, namespaces, validate, web, merge
 
 logging.basicConfig(
     format="%(asctime)s,%(msecs)03d %(levelname)-7s [%(filename)s:%(lineno)d] %(message)s",

--- a/brickschema/__init__.py
+++ b/brickschema/__init__.py
@@ -16,4 +16,4 @@ logging.basicConfig(
 
 
 __version__ = "0.2.0"
-__all__ = ["graph", "inference", "namespaces", "orm", "validate", "web", "merge"]
+__all__ = ["graph", "inference", "namespaces", "validate", "web", "merge"]

--- a/brickschema/__init__.py
+++ b/brickschema/__init__.py
@@ -16,4 +16,4 @@ logging.basicConfig(
 
 
 __version__ = "0.2.0"
-__all__ = ["graph", "inference", "namespaces", "validate", "web", "merge"]
+__all__ = ["graph", "inference", "namespaces", "validate"]

--- a/brickschema/brickify/main.py
+++ b/brickschema/brickify/main.py
@@ -3,18 +3,27 @@ The `main` module provides the CLI tool.
 """
 
 from pathlib import Path
+from warnings import warn
 
-import typer
+try:
+    import typer
 
-from brickschema.brickify.src.handlers.Handler.Handler import Handler
-from brickschema.brickify.src.handlers.Handler.HaystackHandler.HaystackHandler import (
-    HaystackHandler,
-)
-from brickschema.brickify.src.handlers.Handler.RACHandler.RACHandler import RACHandler
-from brickschema.brickify.src.handlers.Handler.TableHandler import TableHandler
-from brickschema.brickify.util import minify_graph
+    from brickschema.brickify.src.handlers.Handler.Handler import Handler
+    from brickschema.brickify.src.handlers.Handler.HaystackHandler.HaystackHandler import (
+        HaystackHandler,
+    )
+    from brickschema.brickify.src.handlers.Handler.RACHandler.RACHandler import (
+        RACHandler,
+    )
+    from brickschema.brickify.src.handlers.Handler.TableHandler import TableHandler
+    from brickschema.brickify.util import minify_graph
+except ImportError:
+    warn(
+        "brickschema needs to be installed with the 'brickify' option:\n\n\tpip install brickschema[brickify]"
+    )
+    import sys
 
-from typing import List
+    sys.exit(1)
 
 app = typer.Typer()
 

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -22,7 +22,6 @@ from .inference import (
     VBISTagInferenceSession,
 )
 from . import namespaces as ns
-from . import web
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -114,6 +113,15 @@ class BrickBase(rdflib.Graph):
           address (str): <host>:<port> of the web server
           ignore_prefixes (list[str]): list of prefixes not to be added to the query editor's namespace bindings.
         """
+        try:
+            from . import web
+        except ImportError:
+            print(
+                "Using the webserver requires the 'web' option:\n\n\tpip install brickschema[web]"
+            )
+            import sys
+
+            sys.exit(1)
         srv = web.Server(self, ignore_prefixes=ignore_prefixes)
         srv.start(address)
 

--- a/brickschema/graph.py
+++ b/brickschema/graph.py
@@ -116,7 +116,7 @@ class BrickBase(rdflib.Graph):
         try:
             from . import web
         except ImportError:
-            print(
+            warn(
                 "Using the webserver requires the 'web' option:\n\n\tpip install brickschema[web]"
             )
             import sys
@@ -209,7 +209,9 @@ class BrickBase(rdflib.Graph):
                     self._inferbackend = OWLRLReasonableInferenceSession()
                     backend = "reasonable"
             except ImportError:
-                logger.info("Could not load Reasonable reasoner")
+                warn(
+                    "Could not load Reasonable reasoner. Needs 'reasonable' option during install."
+                )
                 self._inferbackend = OWLRLNaiveInferenceSession()
 
             try:
@@ -217,7 +219,9 @@ class BrickBase(rdflib.Graph):
                     self._inferbackend = OWLRLAllegroInferenceSession()
                     backend = "allegrograph"
             except (ImportError, ConnectionError):
-                logger.info("Could not load Allegro reasoner")
+                warn(
+                    "Could not load Allegro reasoner. Needs 'allegro' option during install."
+                )
                 self._inferbackend = OWLRLNaiveInferenceSession()
         elif profile == "vbis":
             self._inferbackend = VBISTagInferenceSession(

--- a/brickschema/inference.py
+++ b/brickschema/inference.py
@@ -5,7 +5,6 @@ import itertools
 import csv
 import secrets
 import re
-import os
 import pkgutil
 import io
 import pickle

--- a/brickschema/orm.py
+++ b/brickschema/orm.py
@@ -1,11 +1,19 @@
 """
 ORM for Brick
 """
-from collections import defaultdict
 from . import namespaces as ns
-from sqlalchemy import Column, String, ForeignKey, create_engine
-from sqlalchemy.orm import relationship, sessionmaker
-from sqlalchemy.ext.declarative import declarative_base
+
+try:
+    from sqlalchemy import Column, String, ForeignKey, create_engine
+    from sqlalchemy.orm import relationship, sessionmaker
+    from sqlalchemy.ext.declarative import declarative_base
+except ImportError:
+    print(
+        "SQLAlchemy not found. Please install brickschema with the 'orm' option:\n\n\tpip install brickschema[orm]"
+    )
+    import sys
+
+    sys.exit(1)
 
 Base = declarative_base()
 # TODO: brick:feeds (many-to-many), brick:hasPart

--- a/brickschema/web.py
+++ b/brickschema/web.py
@@ -48,7 +48,12 @@ class Server:
 
     def bindings(self):
         return jsonify(
-            {prefix: namespace for prefix, namespace in self.graph.namespaces() if prefix not in self.ignore_prefixes})
+            {
+                prefix: namespace
+                for prefix, namespace in self.graph.namespaces()
+                if prefix not in self.ignore_prefixes
+            }
+        )
 
     def apply_reasoning(self, profile):
         self.graph.expand(profile)

--- a/brickschema/web.py
+++ b/brickschema/web.py
@@ -6,7 +6,7 @@ Brickschema web module. This embeds a Flask webserver which provides a local web
 TODO:
 - implement https://www.w3.org/TR/sparql11-protocol/ on /query
 """
-from flask import Flask, request, json, jsonify, redirect
+from flask import Flask, request, json, jsonify
 from rdflib.plugins.sparql.results.jsonresults import JSONResultSerializer
 import pkgutil
 import io

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,21 +285,20 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "flask"
-version = "1.1.2"
+version = "2.0.3"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-click = ">=5.1"
-itsdangerous = ">=0.24"
-Jinja2 = ">=2.10.1"
-Werkzeug = ">=0.15"
+click = ">=7.1.2"
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.0"
 
 [package.extras]
-dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
-docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
+async = ["asgiref (>=3.2)"]
 dotenv = ["python-dotenv"]
 
 [[package]]
@@ -1174,7 +1173,7 @@ web = ["Flask"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "111917338ca64c5d3bf408f96b90a5f2f07553a419309aa5aca97c79a846cba1"
+content-hash = "e7217a051c886d90ba366c2570a794a11aac7a274b20653d7e3f07b768ca2e82"
 
 [metadata.files]
 affinegap = [
@@ -1550,8 +1549,8 @@ flake8 = [
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 flask = [
-    {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
-    {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
+    {file = "Flask-2.0.3-py3-none-any.whl", hash = "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"},
+    {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,23 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "alembic"
+version = "1.7.6"
+description = "A database migration tool for SQLAlchemy."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.9\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
+Mako = "*"
+SQLAlchemy = ">=1.3.0"
+
+[package.extras]
+tz = ["python-dateutil"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -448,6 +465,21 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "mako"
+version = "1.1.6"
+description = "A super-fast templating language that borrows the  best ideas from the existing templating languages."
+category = "main"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+MarkupSafe = ">=0.9.2"
+
+[package.extras]
+babel = ["babel"]
+lingua = ["lingua"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.0"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -781,6 +813,20 @@ pyparsing = "*"
 docs = ["sphinx (<5)", "sphinxcontrib-apidoc"]
 html = ["html5lib"]
 tests = ["berkeleydb", "html5lib", "networkx", "pytest", "pytest-cov", "pytest-subtests"]
+
+[[package]]
+name = "rdflib-sqlalchemy"
+version = "0.5.0"
+description = "rdflib extension adding SQLAlchemy as an AbstractSQLStore back-end store"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.dependencies]
+alembic = ">=0.8.8"
+rdflib = ">=4.0"
+six = ">=1.10.0"
+SQLAlchemy = ">=1.1.4"
 
 [[package]]
 name = "reasonable"
@@ -1162,18 +1208,19 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [extras]
-all = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy"]
+all = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy", "rdflib_sqlalchemy"]
 allegro = []
 brickify = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer"]
 merge = ["dedupe", "colorama"]
 orm = ["sqlalchemy"]
+persistence = ["rdflib_sqlalchemy", "sqlalchemy"]
 reasonable = ["reasonable"]
 web = ["Flask"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e7217a051c886d90ba366c2570a794a11aac7a274b20653d7e3f07b768ca2e82"
+content-hash = "44475f3f69937b414f23aeb734e57baad5cc775b3a3e46c3af5dacc39880c30e"
 
 [metadata.files]
 affinegap = [
@@ -1242,6 +1289,10 @@ affinegap = [
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+alembic = [
+    {file = "alembic-1.7.6-py3-none-any.whl", hash = "sha256:ad842f2c3ab5c5d4861232730779c05e33db4ba880a08b85eb505e87c01095bc"},
+    {file = "alembic-1.7.6.tar.gz", hash = "sha256:6c0c05e9768a896d804387e20b299880fe01bc56484246b0dffe8075d6d3d847"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1700,6 +1751,10 @@ levenshtein-search = [
     {file = "Levenshtein_search-1.4.5-cp38-cp38-win_amd64.whl", hash = "sha256:c7d785b5546c3d82e76dc769b1b403f3282f4e0037a2ae0cef07e11165a4e9dc"},
     {file = "Levenshtein_search-1.4.5.tar.gz", hash = "sha256:4034569cb652b00a928f5417bf312c3935a9fd493759ff116d779c44f2f437e2"},
 ]
+mako = [
+    {file = "Mako-1.1.6-py2.py3-none-any.whl", hash = "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"},
+    {file = "Mako-1.1.6.tar.gz", hash = "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2"},
+]
 markupsafe = [
     {file = "MarkupSafe-2.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c"},
     {file = "MarkupSafe-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a"},
@@ -2065,6 +2120,10 @@ pyyaml = [
 rdflib = [
     {file = "rdflib-6.1.1-py3-none-any.whl", hash = "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"},
     {file = "rdflib-6.1.1.tar.gz", hash = "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754"},
+]
+rdflib-sqlalchemy = [
+    {file = "rdflib-sqlalchemy-0.5.0.tar.gz", hash = "sha256:38f1a71a93b8ea9fde0c7749a6eeec76a513d7324abb2e2222635eb095c078e0"},
+    {file = "rdflib_sqlalchemy-0.5.0-py3-none-any.whl", hash = "sha256:ab0c898ae14babcef1ab18d050e49cf4a4ab6a24664517032c24b5e63e20d285"},
 ]
 reasonable = [
     {file = "reasonable-0.1.53-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8285b30becfc0f145e528cf06db24c1158f85c37b5ff63b0b277d4b462a4b3d0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -104,7 +104,7 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.10"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -154,7 +154,7 @@ python-dateutil = ">=2.6.0"
 
 [[package]]
 name = "dedupe"
-version = "2.0.11"
+version = "2.0.13"
 description = "A python library for accurate and scaleable data deduplication and entity-resolution"
 category = "main"
 optional = false
@@ -167,14 +167,17 @@ categorical-distance = ">=1.9"
 dedupe-hcluster = "*"
 dedupe-variable-datetime = "*"
 doublemetaphone = "*"
-fastcluster = "*"
+fastcluster = [
+    {version = "*", markers = "python_version < \"3.10\""},
+    {url = "https://github.com/dmuellner/fastcluster/archive/dbbf09361745c422517095fe783960782f7cc370.zip", markers = "python_version >= \"3.10\""},
+]
 haversine = ">=0.4.1"
 highered = ">=0.2.0"
-Levenshtein-search = "1.4.5"
+Levenshtein_search = "1.4.5"
 numpy = ">=1.13"
 rlr = ">=2.4.3"
 simplecosine = ">=1.2"
-typing-extensions = "*"
+typing_extensions = "*"
 "zope.index" = "*"
 
 [[package]]
@@ -256,7 +259,7 @@ test = ["scipy (>=1.6.3)"]
 
 [[package]]
 name = "filelock"
-version = "3.4.2"
+version = "3.6.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -340,7 +343,7 @@ pyhacrf-datamade = ">=0.2.0"
 
 [[package]]
 name = "identify"
-version = "2.4.6"
+version = "2.4.11"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -367,7 +370,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.10.1"
+version = "4.11.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -380,7 +383,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -447,11 +450,11 @@ python-versions = "*"
 
 [[package]]
 name = "markupsafe"
-version = "2.0.1"
+version = "2.1.0"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "mccabe"
@@ -517,7 +520,7 @@ test = ["zope.testrunner", "manuel"]
 
 [[package]]
 name = "platformdirs"
-version = "2.4.1"
+version = "2.5.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -1052,7 +1055,7 @@ doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
+version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
@@ -1073,7 +1076,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.13.0"
+version = "20.13.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1365,8 +1368,8 @@ cfgv = [
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
-    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
@@ -1386,56 +1389,7 @@ datetime-distance = [
     {file = "datetime_distance-0.1.3-py3-none-any.whl", hash = "sha256:93034ebadc7efb76c55789737c4e5d9f6aeaed4af6a672058b9c1f11a2118d4c"},
 ]
 dedupe = [
-    {file = "dedupe-2.0.11-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ceec668160dae9ca2f11f579046a6f22083dfa869937a4220e3152792f5e9a2"},
-    {file = "dedupe-2.0.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5ae299a4b447f27eafa4d39a4e718d2e8ddb2ff5469e7df96c4b44a1b3a8979f"},
-    {file = "dedupe-2.0.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3aacf0ec1d73025ad40766928d0cfe288bcd8649d6585b028073d4b2b78b68f8"},
-    {file = "dedupe-2.0.11-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b02b74395a7e9f5a7431483fc423ab42b97e71da478007226c3a7c3677262bb"},
-    {file = "dedupe-2.0.11-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74fdfd360ab12132567732fc860d303a27dadb9c49161b47c346314d7f69e5a4"},
-    {file = "dedupe-2.0.11-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0c1c96159b565a89030c7bd585a9531798f8ad489c885fc761daab773f117fe8"},
-    {file = "dedupe-2.0.11-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9486fda6d37854e965449833a0039ae196e0de000139ef0e320c4ebd1ea97d67"},
-    {file = "dedupe-2.0.11-cp310-cp310-win32.whl", hash = "sha256:2829652c04ea72ee368f0a647148e1055e14395c39d12b9e306dd608141b8b73"},
-    {file = "dedupe-2.0.11-cp310-cp310-win_amd64.whl", hash = "sha256:75342d6531fb8d76cd6b8055c3e70a69100bfab937d4826bffebfe48f80f4550"},
-    {file = "dedupe-2.0.11-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:95d6eddf2982b7f9759f192f66fce92e092e4f386e8867b9546f4e60f153a351"},
-    {file = "dedupe-2.0.11-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec2645fe296251366e046ad942b282b7da145df6e632c9a4375a514b134709d3"},
-    {file = "dedupe-2.0.11-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7f7ce7a48b978b7f6a06438cff6199595f092b265e51a2bbfc1fef92294a2f4"},
-    {file = "dedupe-2.0.11-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:c8e3b58442f972a4788a3543cc9c57ddb0cf20619f47cc317eba596a19141dba"},
-    {file = "dedupe-2.0.11-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a1a25d399a2a198b37999cf2c222d8f992e62c5ffc62d87f3b233df200f4d578"},
-    {file = "dedupe-2.0.11-cp36-cp36m-win32.whl", hash = "sha256:5af7a9f304ff27e8e4e7cf56840b51e7fb961ec44097bcd934d41b79a64bd07e"},
-    {file = "dedupe-2.0.11-cp36-cp36m-win_amd64.whl", hash = "sha256:824126b7bdd018d60d04ebc45b1fe3bf9a380a13c2cc30ac3a1d97fe978cf85b"},
-    {file = "dedupe-2.0.11-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb3d9c32af134ae656cfba3babf02b7a70e1efdc1cdf8cfc1253cf7241e05d2"},
-    {file = "dedupe-2.0.11-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:72e03f94199c67a916a2eb824c30ca86e133c0f3f63b0108f2b26fbdb8f83f62"},
-    {file = "dedupe-2.0.11-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832cff501104ead4092755f98a346ea806ac74d34572b5495444966bdc264bd8"},
-    {file = "dedupe-2.0.11-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f4be127dd02a73dcde3bdda718fa27d391397a77f0847ed6b4dbd800abcc6fa8"},
-    {file = "dedupe-2.0.11-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c861fbf97aa8792beb72abbd716962b53f1ed79bbb8e9d3e64c402604cc485de"},
-    {file = "dedupe-2.0.11-cp37-cp37m-win32.whl", hash = "sha256:01742d93caa396cfa56fbbd7252e2a146f63daf15c692fe7f21e8d189481f7a9"},
-    {file = "dedupe-2.0.11-cp37-cp37m-win_amd64.whl", hash = "sha256:bcea6d6d5eb45feb43b93a6d4eaa8c4085dc808c17d85019e44fab18d170116f"},
-    {file = "dedupe-2.0.11-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:674b273bd797025d7dc71b5ec81be0b3adf581ab8a1f31414743639aacbb445c"},
-    {file = "dedupe-2.0.11-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0cf689b507fe5f44de7a71bb18d1f2ace01f024696f2398ff2b52e091756ad2d"},
-    {file = "dedupe-2.0.11-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ab8a98fabecee1e4a9bfc83315474a1828f5962424797652cd5bd6b52b518502"},
-    {file = "dedupe-2.0.11-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4fa394baa4b422d40a6962c63544df4666645deee801b4e81403136e6045a905"},
-    {file = "dedupe-2.0.11-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ef5b4bb34e538e9f117a85c2e1fe921c4dad5b235c80d7b3945ca830269b537"},
-    {file = "dedupe-2.0.11-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:76fe02d2032c8b928412bb27c941b224ea25a41783ae0c849de33b70aa16997f"},
-    {file = "dedupe-2.0.11-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:dcdd3dd18e3877ff3d29e4c9969e629ddf8208bf4d9ff492dfdbc302b75ba34e"},
-    {file = "dedupe-2.0.11-cp38-cp38-win32.whl", hash = "sha256:b92dd67ab69a5053e9445497577fdd4a0732f507dbdd9e2457703216b6d75c19"},
-    {file = "dedupe-2.0.11-cp38-cp38-win_amd64.whl", hash = "sha256:e20cc7dd7bd63488642220b02a25bfe58c9fe332e7ba731b427cc895c9e74d53"},
-    {file = "dedupe-2.0.11-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:040cf1a74940c72c0802e0e4c801998557b79bea1a5e2f9bd771b73976381d05"},
-    {file = "dedupe-2.0.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fcd5111df1174843066588f563ccd02953961b5d4357a6e6c484ae7153a0bbad"},
-    {file = "dedupe-2.0.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:60777ebaf81c46635abe66c9a1c7971e6fb815de469a24e6cfc6510c0da387d9"},
-    {file = "dedupe-2.0.11-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4d0636dfcc5735386d3e1829a852321d5ce4ad66f6a5f151aab2c2d168e256de"},
-    {file = "dedupe-2.0.11-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0a80cc5b1aa1543e086b6a957dad60c77ad6797e3c8af40709458a70d78f5da"},
-    {file = "dedupe-2.0.11-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:472385e085b6a60cd73254f684394f3344d056c66dda473304c00e781b0a17f7"},
-    {file = "dedupe-2.0.11-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c61551f0d8c03a2b3a4189dc595f34d8ed980c67fa881de5a82736bd7133ea90"},
-    {file = "dedupe-2.0.11-cp39-cp39-win32.whl", hash = "sha256:619303a2dbb35b057f57576d9d4a0e60b70aea4271e126e288c8d1e26fcc4dce"},
-    {file = "dedupe-2.0.11-cp39-cp39-win_amd64.whl", hash = "sha256:2fe7fa41fbbf6e2ff53c4b97b8bad5c66096b707126b092eb2989714d95bf360"},
-    {file = "dedupe-2.0.11-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9adaf511d7584a8a5230a0dc3becf6d419a8a5bafd9d754f532b208015e946ea"},
-    {file = "dedupe-2.0.11-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5127fac7d448c50b84b5aead39ce893ed804ea559eebb2e5dfad2b6fd9ca400a"},
-    {file = "dedupe-2.0.11-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff241aff9edb4e2f8c763fc39f178e0fc49b33c0b2752fbe78bbcaa373dbbf62"},
-    {file = "dedupe-2.0.11-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:26b0894aa7808d26492e9279fffcc40b58ef4fca84b0ffe1404c7a419ece208d"},
-    {file = "dedupe-2.0.11-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fa893c48ce30f31ed8adff69ff00cc8b6875142ac06f21b11695aeeccbc43499"},
-    {file = "dedupe-2.0.11-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf70e5f1219539b05311d200f36c7ab2eca1d417d5fff6f973708e2fa8f6ae89"},
-    {file = "dedupe-2.0.11-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9ff8fbc15604327f1467fbde86fc3603c06df5f3a74476242bf6a507404ad97"},
-    {file = "dedupe-2.0.11-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:fc0d2d4e1c84daab958b88d028d4ffebd015c359360ea75ffedb9c922b5ee04e"},
-    {file = "dedupe-2.0.11.tar.gz", hash = "sha256:ab26516bf8865e192b291500404239aa96a6b5bf0381b7ee75776b962a8938b3"},
+    {file = "dedupe-2.0.13.tar.gz", hash = "sha256:ce1b82e8acc2261214609d7304af840590cc89292f2f933d4b2e0763823b89c5"},
 ]
 dedupe-hcluster = [
     {file = "dedupe-hcluster-0.3.9.tar.gz", hash = "sha256:291e87ef7db4656d7365f7665e7a5e5b7ef9bc83bba49e6c33efe11d9a689dbf"},
@@ -1586,8 +1540,8 @@ fastcluster = [
     {file = "fastcluster-1.2.4.tar.gz", hash = "sha256:b5697a26b5397004bba4ac6308e9e9b7a832dcccfcc0333554bc3898a55601a3"},
 ]
 filelock = [
-    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
-    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1612,6 +1566,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -1624,6 +1579,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -1632,6 +1588,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -1640,6 +1597,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -1648,6 +1606,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
@@ -1661,8 +1620,8 @@ highered = [
     {file = "highered-0.2.1.tar.gz", hash = "sha256:5fcae90599dda98560d6f5347ff88aee56a4b8e7181d009852c3dc699c336fb7"},
 ]
 identify = [
-    {file = "identify-2.4.6-py2.py3-none-any.whl", hash = "sha256:cf06b1639e0dca0c184b1504d8b73448c99a68e004a80524c7923b95f7b6837c"},
-    {file = "identify-2.4.6.tar.gz", hash = "sha256:233679e3f61a02015d4293dbccf16aa0e4996f868bd114688b8c124f18826706"},
+    {file = "identify-2.4.11-py2.py3-none-any.whl", hash = "sha256:fd906823ed1db23c7a48f9b176a1d71cb8abede1e21ebe614bac7bdd688d9213"},
+    {file = "identify-2.4.11.tar.gz", hash = "sha256:2986942d3974c8f2e5019a190523b0b0e2a07cb8e89bf236727fb4b26f27f8fd"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1673,8 +1632,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.10.1-py3-none-any.whl", hash = "sha256:899e2a40a8c4a1aec681feef45733de8a6c58f3f6a0dbed2eb6574b4387a77b6"},
-    {file = "importlib_metadata-4.10.1.tar.gz", hash = "sha256:951f0d8a5b7260e9db5e41d429285b5f451e928479f19d80818878527d36e95e"},
+    {file = "importlib_metadata-4.11.1-py3-none-any.whl", hash = "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"},
+    {file = "importlib_metadata-4.11.1.tar.gz", hash = "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c"},
 ]
 importlib-resources = [
     {file = "importlib_resources-3.3.1-py2.py3-none-any.whl", hash = "sha256:42068585cc5e8c2bf0a17449817401102a5125cbfbb26bb0f43cde1568f6f2df"},
@@ -1741,60 +1700,46 @@ levenshtein-search = [
     {file = "Levenshtein_search-1.4.5.tar.gz", hash = "sha256:4034569cb652b00a928f5417bf312c3935a9fd493759ff116d779c44f2f437e2"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
-    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e104c0c2b4cd765b4e83909cde7ec61a1e313f8a75775897db321450e928cce"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24c3be29abb6b34052fd26fc7a8e0a49b1ee9d282e3665e8ad09a0a68faee5b3"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204730fd5fe2fe3b1e9ccadb2bd18ba8712b111dcabce185af0b3b5285a7c989"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d3b64c65328cb4cd252c94f83e66e3d7acf8891e60ebf588d7b493a55a1dbf26"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:96de1932237abe0a13ba68b63e94113678c379dca45afa040a17b6e1ad7ed076"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75bb36f134883fdbe13d8e63b8675f5f12b80bb6627f7714c7d6c5becf22719f"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-win32.whl", hash = "sha256:4056f752015dfa9828dce3140dbadd543b555afb3252507348c493def166d454"},
+    {file = "MarkupSafe-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:d4e702eea4a2903441f2735799d217f4ac1b55f7d8ad96ab7d4e25417cb0827c"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f0eddfcabd6936558ec020130f932d479930581171368fd728efcfb6ef0dd357"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ddea4c352a488b5e1069069f2f501006b1a4362cb906bee9a193ef1245a7a61"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09c86c9643cceb1d87ca08cdc30160d1b7ab49a8a21564868921959bd16441b8"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0a0abef2ca47b33fb615b491ce31b055ef2430de52c5b3fb19a4042dbc5cadb"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:736895a020e31b428b3382a7887bfea96102c529530299f426bf2e636aacec9e"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:679cbb78914ab212c49c67ba2c7396dc599a8479de51b9a87b174700abd9ea49"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:84ad5e29bf8bab3ad70fd707d3c05524862bddc54dc040982b0dbcff36481de7"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-win32.whl", hash = "sha256:8da5924cb1f9064589767b0f3fc39d03e3d0fb5aa29e0cb21d43106519bd624a"},
+    {file = "MarkupSafe-2.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:454ffc1cbb75227d15667c09f164a0099159da0c1f3d2636aa648f12675491ad"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:142119fb14a1ef6d758912b25c4e803c3ff66920635c44078666fe7cc3f8f759"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b2a5a856019d2833c56a3dcac1b80fe795c95f401818ea963594b345929dffa7"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d1fb9b2eec3c9714dd936860850300b51dbaa37404209c8d4cb66547884b7ed"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62c0285e91414f5c8f621a17b69fc0088394ccdaa961ef469e833dbff64bd5ea"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fc3150f85e2dbcf99e65238c842d1cfe69d3e7649b19864c1cc043213d9cd730"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f02cf7221d5cd915d7fa58ab64f7ee6dd0f6cddbb48683debf5d04ae9b1c2cc1"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d5653619b3eb5cbd35bfba3c12d575db2a74d15e0e1c08bf1db788069d410ce8"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7d2f5d97fcbd004c03df8d8fe2b973fe2b14e7bfeb2cfa012eaa8759ce9a762f"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-win32.whl", hash = "sha256:3cace1837bc84e63b3fd2dfce37f08f8c18aeb81ef5cf6bb9b51f625cb4e6cd8"},
+    {file = "MarkupSafe-2.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:fabbe18087c3d33c5824cb145ffca52eccd053061df1d79d4b66dafa5ad2a5ea"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:023af8c54fe63530545f70dd2a2a7eed18d07a9a77b94e8bf1e2ff7f252db9a3"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d66624f04de4af8bbf1c7f21cc06649c1c69a7f84109179add573ce35e46d448"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c532d5ab79be0199fa2658e24a02fce8542df196e60665dd322409a03db6a52c"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67ec74fada3841b8c5f4c4f197bea916025cb9aa3fe5abf7d52b655d042f956"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30c653fde75a6e5eb814d2a0a89378f83d1d3f502ab710904ee585c38888816c"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:961eb86e5be7d0973789f30ebcf6caab60b844203f4396ece27310295a6082c7"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:598b65d74615c021423bd45c2bc5e9b59539c875a9bdb7e5f2a6b92dfcfc268d"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:599941da468f2cf22bf90a84f6e2a65524e87be2fce844f96f2dd9a6c9d1e635"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-win32.whl", hash = "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05"},
+    {file = "MarkupSafe-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7"},
+    {file = "MarkupSafe-2.1.0.tar.gz", hash = "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -1896,8 +1841,8 @@ persistent = [
     {file = "persistent-4.7.0.tar.gz", hash = "sha256:0ef7c05a6dca0104dc224fe7ff31feb30a63d970421c9462104a4752148ac333"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
-    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -2231,16 +2176,16 @@ typer = [
     {file = "typer-0.3.2.tar.gz", hash = "sha256:5455d750122cff96745b0dec87368f56d023725a7ebc9d2e54dd23dc86816303"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},
-    {file = "virtualenv-20.13.0.tar.gz", hash = "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"},
+    {file = "virtualenv-20.13.1-py2.py3-none-any.whl", hash = "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7"},
+    {file = "virtualenv-20.13.1.tar.gz", hash = "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -3,7 +3,7 @@ name = "affinegap"
 version = "1.12"
 description = "A Cython implementation of the affine gap string distance"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -52,7 +52,7 @@ name = "btrees"
 version = "4.9.2"
 description = "Scalable persistent object containers"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -69,7 +69,7 @@ name = "categorical-distance"
 version = "1.9"
 description = "Compare two categorical variables"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -88,7 +88,7 @@ name = "cffi"
 version = "1.15.0"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -118,7 +118,7 @@ name = "click"
 version = "7.1.2"
 description = "Composable command line interface toolkit"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
@@ -126,7 +126,7 @@ name = "click-spinner"
 version = "0.1.10"
 description = "Spinner for Click"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -145,7 +145,7 @@ name = "datetime-distance"
 version = "0.1.3"
 description = "Compare string distances between dates, timestamps, or datetime objects."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -157,7 +157,7 @@ name = "dedupe"
 version = "2.0.13"
 description = "A python library for accurate and scaleable data deduplication and entity-resolution"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -185,7 +185,7 @@ name = "dedupe-hcluster"
 version = "0.3.9"
 description = "Hierarchical Clustering Algorithms (Information Theory)"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -200,7 +200,7 @@ name = "dedupe-variable-datetime"
 version = "0.1.5"
 description = "DateTime variable type for dedupe"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -229,7 +229,7 @@ name = "doublemetaphone"
 version = "1.1"
 description = "Python wrapper for C++ Double Metaphone"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -248,7 +248,7 @@ name = "fastcluster"
 version = "1.2.4"
 description = "Fast hierarchical clustering routines for R and Python."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3"
 
 [package.dependencies]
@@ -288,7 +288,7 @@ name = "flask"
 version = "1.1.4"
 description = "A simple framework for building complex web applications."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
@@ -307,7 +307,7 @@ name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -315,7 +315,7 @@ name = "greenlet"
 version = "1.1.2"
 description = "Lightweight in-process concurrent programming"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
@@ -326,7 +326,7 @@ name = "haversine"
 version = "2.5.1"
 description = "Calculate the distance between 2 points on Earth."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -334,7 +334,7 @@ name = "highered"
 version = "0.2.1"
 description = "Learnable Edit Distance Using PyHacrf"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -423,7 +423,7 @@ name = "itsdangerous"
 version = "1.1.0"
 description = "Various helpers to pass data to untrusted environments and back."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -445,7 +445,7 @@ name = "levenshtein-search"
 version = "1.4.5"
 description = "Search through documents for approximately matching strings"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -477,7 +477,7 @@ name = "numpy"
 version = "1.21.1"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [[package]]
@@ -507,7 +507,7 @@ name = "persistent"
 version = "4.7.0"
 description = "Translucent persistent objects"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -609,7 +609,7 @@ name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -633,7 +633,7 @@ name = "pyhacrf-datamade"
 version = "0.2.6"
 description = "Hidden alignment conditional random field, a discriminative string edit distance"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -649,7 +649,7 @@ name = "pylbfgs"
 version = "0.2.0.14"
 description = "LBFGS and OWL-QN optimization algorithms"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -743,7 +743,7 @@ name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
@@ -784,6 +784,14 @@ html = ["html5lib"]
 tests = ["berkeleydb", "html5lib", "networkx", "pytest", "pytest-cov", "pytest-subtests"]
 
 [[package]]
+name = "reasonable"
+version = "0.1.53"
+description = "An OWL 2 RL reasoner with reasonable performance"
+category = "main"
+optional = true
+python-versions = "^3.7"
+
+[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -806,7 +814,7 @@ name = "rlr"
 version = "2.4.6"
 description = "Case weighted L2 regularized logistic regression"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -814,19 +822,11 @@ numpy = ">=1.13.1"
 pylbfgs = "*"
 
 [[package]]
-name = "shellingham"
-version = "1.4.0"
-description = "Tool to Detect Surrounding Shell"
-category = "main"
-optional = false
-python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,>=2.6"
-
-[[package]]
 name = "simplecosine"
 version = "1.2"
 description = "Simple cosine distance"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -971,7 +971,7 @@ name = "sqlalchemy"
 version = "1.4.31"
 description = "Database Abstraction Library"
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
@@ -1004,7 +1004,7 @@ name = "tabulate"
 version = "0.8.9"
 description = "Pretty-print tabular data"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -1039,13 +1039,11 @@ name = "typer"
 version = "0.3.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
 click = ">=7.1.1,<7.2.0"
-colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
-shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
 
 [package.extras]
 test = ["pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.782)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)", "shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)"]
@@ -1106,7 +1104,7 @@ name = "werkzeug"
 version = "1.0.1"
 description = "The comprehensive WSGI web application library."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
@@ -1118,7 +1116,7 @@ name = "xlrd"
 version = "1.2.0"
 description = "Library for developers to extract data from Microsoft Excel (tm) spreadsheet files"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -1138,7 +1136,7 @@ name = "zope.index"
 version = "5.1.0"
 description = "Indices for using with catalog like text, field, etc."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1157,7 +1155,7 @@ name = "zope.interface"
 version = "5.4.0"
 description = "Interfaces for Python"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
@@ -1166,13 +1164,18 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [extras]
+all = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy"]
 allegro = []
-reasonable = []
+brickify = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer"]
+merge = ["dedupe", "colorama"]
+orm = ["sqlalchemy"]
+reasonable = ["reasonable"]
+web = ["Flask"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "b525cc3f92dca046cbe4c907542cec3d3daafb2d82e8daaae4ce5549aebef8d8"
+content-hash = "113342e0717eee9dc75ff3198c45e08ee5685e268cf7ff6df7a8d55631c3b4fe"
 
 [metadata.files]
 affinegap = [
@@ -2065,6 +2068,12 @@ rdflib = [
     {file = "rdflib-6.1.1-py3-none-any.whl", hash = "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"},
     {file = "rdflib-6.1.1.tar.gz", hash = "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754"},
 ]
+reasonable = [
+    {file = "reasonable-0.1.53-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8285b30becfc0f145e528cf06db24c1158f85c37b5ff63b0b277d4b462a4b3d0"},
+    {file = "reasonable-0.1.53-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e0d716f46cee7e6b8b3d5a04cd3c49d3e99d938134d3a41da14536cf8d340743"},
+    {file = "reasonable-0.1.53-cp37-abi3-win_amd64.whl", hash = "sha256:f46ce373aeb71539ade93d42a1a1d464556863369d05cfb45219798f87dbb9e2"},
+    {file = "reasonable-0.1.53.tar.gz", hash = "sha256:10a2fb390b3f0e172ade722d51f0db86a6bb40da18230331ad75252a21e61f4c"},
+]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
@@ -2072,10 +2081,6 @@ requests = [
 rlr = [
     {file = "rlr-2.4.6-py2.py3-none-any.whl", hash = "sha256:dcdd918a29d7b5a2e09f55a8b1e148227cb4c82fa23d8f3c17887157f3df7ad8"},
     {file = "rlr-2.4.6.tar.gz", hash = "sha256:cf45ac6a8f4b0086f1a18f52761d16ce18b0cf1b33193d77f4fa57adc58895f7"},
-]
-shellingham = [
-    {file = "shellingham-1.4.0-py2.py3-none-any.whl", hash = "sha256:536b67a0697f2e4af32ab176c00a50ac2899c5a05e0d8e2dadac8e58888283f9"},
-    {file = "shellingham-1.4.0.tar.gz", hash = "sha256:4855c2458d6904829bd34c299f11fdeed7cfefbf8a2c522e4caea6cd76b3171e"},
 ]
 simplecosine = [
     {file = "simplecosine-1.2-py2.py3-none-any.whl", hash = "sha256:aa3ee50913d5bd990c755e6e1dc76944eb179b0709932b99a8f6986fc8bc7430"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -285,17 +285,17 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "flask"
-version = "1.1.4"
+version = "1.1.2"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
-click = ">=5.1,<8.0"
-itsdangerous = ">=0.24,<2.0"
-Jinja2 = ">=2.10.1,<3.0"
-Werkzeug = ">=0.15,<2.0"
+click = ">=5.1"
+itsdangerous = ">=0.24"
+Jinja2 = ">=2.10.1"
+Werkzeug = ">=0.15"
 
 [package.extras]
 dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
@@ -420,25 +420,25 @@ six = "*"
 
 [[package]]
 name = "itsdangerous"
-version = "1.1.0"
-description = "Various helpers to pass data to untrusted environments and back."
+version = "2.1.0"
+description = "Safely pass data to untrusted environments and back."
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 
 [[package]]
 name = "jinja2"
-version = "2.11.3"
+version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-MarkupSafe = ">=0.23"
+MarkupSafe = ">=2.0"
 
 [package.extras]
-i18n = ["Babel (>=0.8)"]
+i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "levenshtein-search"
@@ -1101,14 +1101,13 @@ python-versions = "*"
 
 [[package]]
 name = "werkzeug"
-version = "1.0.1"
+version = "2.0.3"
 description = "The comprehensive WSGI web application library."
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.extras]
-dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
 watchdog = ["watchdog"]
 
 [[package]]
@@ -1175,7 +1174,7 @@ web = ["Flask"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "113342e0717eee9dc75ff3198c45e08ee5685e268cf7ff6df7a8d55631c3b4fe"
+content-hash = "111917338ca64c5d3bf408f96b90a5f2f07553a419309aa5aca97c79a846cba1"
 
 [metadata.files]
 affinegap = [
@@ -1551,8 +1550,8 @@ flake8 = [
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 flask = [
-    {file = "Flask-1.1.4-py2.py3-none-any.whl", hash = "sha256:c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"},
-    {file = "Flask-1.1.4.tar.gz", hash = "sha256:0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196"},
+    {file = "Flask-1.1.2-py2.py3-none-any.whl", hash = "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"},
+    {file = "Flask-1.1.2.tar.gz", hash = "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -1651,12 +1650,12 @@ isodate = [
     {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
 ]
 itsdangerous = [
-    {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
-    {file = "itsdangerous-1.1.0.tar.gz", hash = "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"},
+    {file = "itsdangerous-2.1.0-py3-none-any.whl", hash = "sha256:29285842166554469a56d427addc0843914172343784cb909695fdbe90a3e129"},
+    {file = "itsdangerous-2.1.0.tar.gz", hash = "sha256:d848fcb8bc7d507c4546b448574e8a44fc4ea2ba84ebf8d783290d53e81992f5"},
 ]
 jinja2 = [
-    {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
-    {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 levenshtein-search = [
     {file = "Levenshtein_search-1.4.5-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:e8896816d6f978016bf09122aacf611112b2966a849d84e9b49aac5cb47c6909"},
@@ -2197,8 +2196,8 @@ wcwidth = [
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 werkzeug = [
-    {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},
-    {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
+    {file = "Werkzeug-2.0.3-py3-none-any.whl", hash = "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8"},
+    {file = "Werkzeug-2.0.3.tar.gz", hash = "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"},
 ]
 xlrd = [
     {file = "xlrd-1.2.0-py2.py3-none-any.whl", hash = "sha256:e551fb498759fa3a5384a94ccd4c3c02eb7c00ea424426e212ac0c57be9dfbde"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ colorama = {optional = true, version="^0.4.4"}
 dedupe = {optional = true, version = "^2.0"}
 reasonable = {optional = true, version="^0.1.53"}
 sqlalchemy = {optional = true, version="^1.3"}
+rdflib_sqlalchemy = {optional = true, version = "^0.5"}
 
 [tool.poetry.scripts]
 brick_validate = "brickschema.bin.brick_validate:main"
@@ -39,7 +40,8 @@ web = ["Flask"]
 merge = ["dedupe", "colorama"]
 orm = ["sqlalchemy"]
 reasonable = ["reasonable"]
-all = ["docker","click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy"]
+persistence = ["rdflib_sqlalchemy", "sqlalchemy"]
+all = ["docker","click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy", "rdflib_sqlalchemy"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ sqlalchemy = "^1.3"
 pytest = "^6.2"
 pyshacl = "^0.18"
 requests = "^2.25.0"
-Flask = "^1.1.2"
+Flask = {optional = true, version = "^1.1.2"}
 typer = {extras = ["all"], version = "^0.3.2"}
 xlrd = "^1.2.0"
 tabulate = "^0.8.7"
@@ -35,6 +35,8 @@ brickify = "brickschema.brickify.main:app"
 reasonable = ["reasonable"]
 allegro = ["docker"]
 merge = ["dedupe"]
+web = ["Flask"]
+brickify = ["Flask", "typer"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,17 @@ pytest = "^6.2"
 pyshacl = "^0.18"
 requests = "^2.25.0"
 importlib-resources = "^3.3.0"
-click-spinner = {optional = true, extras = ["all", "brickify"], version="^0.1.10"}
-tabulate = {optional = true, extras = ["all", "brickify"], version="^0.8.7"}
-Jinja2 = {optional = true, extras = ["all", "brickify"], version="^2.11.2"}
-xlrd = {optional = true, extras = ["all", "brickify"], version="^1.2.0"}
-PyYAML = {optional = true, extras = ["all", "brickify"], version="^5.3.1"}
-typer = {optional = true, extras = ["all", "brickify"], version = "^0.3.2"}
-Flask = {optional = true, extras = ["all", "web"], version = "^1.1.2"}
-colorama = {optional = true, extras = ["all", "merge"], version="^0.4.4"}
-dedupe = {optional = true, extras = ["all", "merge"], version = "^2.0"}
-reasonable = {optional = true, extras = ["all", "reasonable"], version="^0.1"}
-sqlalchemy = {optional = true, extras = ["all", "orm"], version="^1.3"}
+click-spinner = {optional = true, version="^0.1.10"}
+tabulate = {optional = true, version="^0.8.7"}
+Jinja2 = {optional = true, version="^2.11.2"}
+xlrd = {optional = true, version="^1.2.0"}
+PyYAML = {optional = true, version="^5.3.1"}
+typer = {optional = true, version = "^0.3.2"}
+Flask = {optional = true, version = "^1.1.2"}
+colorama = {optional = true, version="^0.4.4"}
+dedupe = {optional = true, version = "^2.0"}
+reasonable = {optional = true, version="^0.1"}
+sqlalchemy = {optional = true, version="^1.3"}
 
 [tool.poetry.scripts]
 brick_validate = "brickschema.bin.brick_validate:main"
@@ -34,6 +34,12 @@ brickify = "brickschema.brickify.main:app"
 
 [tool.poetry.extras]
 allegro = ["docker"]
+brickify = ["click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer"]
+web = ["Flask"]
+merge = ["dedupe", "colorama"]
+orm = ["sqlalchemy"]
+reasonable = ["reasonable"]
+all = ["docker","click-spinner", "tabulate", "Jinja2", "xlrd", "PyYAML", "typer", "Flask", "dedupe", "colorama", "reasonable", "sqlalchemy"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ typer = {optional = true, version = "^0.3.2"}
 Flask = {optional = true, version = "^1.1.2"}
 colorama = {optional = true, version="^0.4.4"}
 dedupe = {optional = true, version = "^2.0"}
-reasonable = {optional = true, version="^0.1"}
+reasonable = {optional = true, version="^0.1.53"}
 sqlalchemy = {optional = true, version="^1.3"}
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ importlib-resources = "^3.3.0"
 click-spinner = "^0.1.10"
 PyYAML = "^5.3.1"
 Jinja2 = "^2.11.2"
-dedupe = "^2.0.8"
 colorama = "^0.4.4"
+dedupe = {optional = true, version = "^2.0"}
 
 [tool.poetry.scripts]
 brick_validate = "brickschema.bin.brick_validate:main"
@@ -34,6 +34,7 @@ brickify = "brickschema.brickify.main:app"
 [tool.poetry.extras]
 reasonable = ["reasonable"]
 allegro = ["docker"]
+merge = ["dedupe"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,31 +12,28 @@ readme = "README.md"
 python = "^3.7"
 rdflib = "^6.1"
 owlrl = "^6.0"
-sqlalchemy = "^1.3"
 pytest = "^6.2"
 pyshacl = "^0.18"
 requests = "^2.25.0"
-Flask = {optional = true, version = "^1.1.2"}
-typer = {extras = ["all"], version = "^0.3.2"}
-xlrd = "^1.2.0"
-tabulate = "^0.8.7"
 importlib-resources = "^3.3.0"
-click-spinner = "^0.1.10"
-PyYAML = "^5.3.1"
-Jinja2 = "^2.11.2"
-colorama = "^0.4.4"
-dedupe = {optional = true, version = "^2.0"}
+click-spinner = {optional = true, extras = ["all", "brickify"], version="^0.1.10"}
+tabulate = {optional = true, extras = ["all", "brickify"], version="^0.8.7"}
+Jinja2 = {optional = true, extras = ["all", "brickify"], version="^2.11.2"}
+xlrd = {optional = true, extras = ["all", "brickify"], version="^1.2.0"}
+PyYAML = {optional = true, extras = ["all", "brickify"], version="^5.3.1"}
+typer = {optional = true, extras = ["all", "brickify"], version = "^0.3.2"}
+Flask = {optional = true, extras = ["all", "web"], version = "^1.1.2"}
+colorama = {optional = true, extras = ["all", "merge"], version="^0.4.4"}
+dedupe = {optional = true, extras = ["all", "merge"], version = "^2.0"}
+reasonable = {optional = true, extras = ["all", "reasonable"], version="^0.1"}
+sqlalchemy = {optional = true, extras = ["all", "orm"], version="^1.3"}
 
 [tool.poetry.scripts]
 brick_validate = "brickschema.bin.brick_validate:main"
 brickify = "brickschema.brickify.main:app"
 
 [tool.poetry.extras]
-reasonable = ["reasonable"]
 allegro = ["docker"]
-merge = ["dedupe"]
-web = ["Flask"]
-brickify = ["Flask", "typer"]
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requests = "^2.25.0"
 importlib-resources = "^3.3.0"
 click-spinner = {optional = true, version="^0.1.10"}
 tabulate = {optional = true, version="^0.8.7"}
-Jinja2 = {optional = true, version="^2.11.2"}
+Jinja2 = {optional = true, version="^3.0"}
 xlrd = {optional = true, version="^1.2.0"}
 PyYAML = {optional = true, version="^5.3.1"}
 typer = {optional = true, version = "^0.3.2"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Jinja2 = {optional = true, version="^3.0"}
 xlrd = {optional = true, version="^1.2.0"}
 PyYAML = {optional = true, version="^5.3.1"}
 typer = {optional = true, version = "^0.3.2"}
-Flask = {optional = true, version = "^1.1.2"}
+Flask = {optional = true, version = "^2.0"}
 colorama = {optional = true, version="^0.4.4"}
 dedupe = {optional = true, version = "^2.0"}
 reasonable = {optional = true, version="^0.1.53"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "brickschema"
-version = "0.5.2a10"
+version = "0.6.0a1"
 description = "A library for working with the Brick ontology for buildings (brickschema.org)"
-authors = ["Gabe Fierro <gtfierro@cs.berkeley.edu>"]
+authors = ["Gabe Fierro <gtfierro@mines.edu>"]
 include = ["brickschema/ontologies", "tests/data", "brickschema/web"]
 homepage = "https://brickschema.org"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Introduces different features for different parts of the brickschema functionality.

- default (no options): just base graph management, querying, inference and validation
- `all`: *all* of the below features
- `web`: `graph.serve()` method supported
- `orm`: experimental ORM module supported
- `brickify`: Brickify tool installed
- `merge`: supports active learning graph merge feature

Also contains some updates to the relevant packages. Prepping for v0.6.0 release