### PR TITLE
Include QUDT ontologies for Brick graph validation

### DIFF
--- a/docs/validate.rst
+++ b/docs/validate.rst
@@ -17,6 +17,12 @@ Example
   from brickschema import Graph
 
   g = Graph(load_brick=True)
+
+  # Load QUDT ontologies from the web
+  g.load_file("http://qudt.org/schema/qudt/")        # QUDT schema
+  g.load_file("http://qudt.org/vocab/quantitykind")  # quantity kinds (e.g., Length, Power)
+  g.load_file("http://qudt.org/vocab/unit")          # units (e.g., Meter, Watt)
+
   g.load_file('myBuilding.ttl')
   valid, _, report = g.validate()
   print(f"Graph is valid? {valid}")


### PR DESCRIPTION
The "Validate" section of the official documentation did not load the QUDT ontologies, resulting in validation errors.